### PR TITLE
Service implementation

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -1,10 +1,10 @@
 [service.api]
-listen_address = ":8045"
-
-[service.api.tls]
-enable = false
-cert_file = ""
-cert_key = ""
+http.listen_address = ":8045"
+http.tls.enable = false
+http.tls.cert_file = ""
+http.tls.cert_key = ""
+admin.enable = false
+admin.secret_key = "admin_secret_key"
 
 [service.rtc]
 ice_port_udp = 8443

--- a/service/auth/crypto.go
+++ b/service/auth/crypto.go
@@ -20,7 +20,7 @@ func newRandomString(length int) (string, error) {
 	} else if n != len(data) {
 		return "", fmt.Errorf("failed to read enough data")
 	}
-	return base64.RawStdEncoding.EncodeToString(data)[:length], nil
+	return base64.RawURLEncoding.EncodeToString(data)[:length], nil
 }
 
 // hashKey generates a hash using the bcrypt.GenerateFromPassword

--- a/service/auth/service.go
+++ b/service/auth/service.go
@@ -25,12 +25,12 @@ func NewService(store store.Store) (*Service, error) {
 	}, nil
 }
 
-func (s *Service) Authenticate(id, authKey string) error {
+func (s *Service) Authenticate(id, authToken string) error {
 	hash, err := s.store.Get(id)
 	if err != nil {
 		return fmt.Errorf("authentication failed: %w", err)
 	}
-	if err := compareKeyHash(hash, authKey); err != nil {
+	if err := compareKeyHash(hash, authToken); err != nil {
 		return fmt.Errorf("authentication failed")
 	}
 	return nil
@@ -43,12 +43,12 @@ func (s *Service) Register(id string) (string, error) {
 		return "", fmt.Errorf("registration failed: %w", err)
 	}
 
-	authKey, err := newRandomString(DefaultKeyLen)
+	authToken, err := newRandomString(DefaultKeyLen)
 	if err != nil {
 		return "", fmt.Errorf("registration failed: %w", err)
 	}
 
-	hash, err := hashKey(authKey)
+	hash, err := hashKey(authToken)
 	if err != nil {
 		return "", fmt.Errorf("registration failed: %w", err)
 	}
@@ -57,7 +57,7 @@ func (s *Service) Register(id string) (string, error) {
 		return "", fmt.Errorf("registration failed: %w", err)
 	}
 
-	return authKey, nil
+	return authToken, nil
 }
 
 func (s *Service) Unregister(id string) error {

--- a/service/auth/service_test.go
+++ b/service/auth/service_test.go
@@ -51,13 +51,13 @@ func TestRegister(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, s)
 
-	authKey, err := s.Register("instanceA")
+	authToken, err := s.Register("instanceA")
 	require.NoError(t, err)
-	require.Len(t, authKey, DefaultKeyLen)
+	require.Len(t, authToken, DefaultKeyLen)
 
-	authKey, err = s.Register("instanceA")
+	authToken, err = s.Register("instanceA")
 	require.Error(t, err)
-	require.Empty(t, authKey)
+	require.Empty(t, authToken)
 	require.EqualError(t, err, "registration failed: already registered")
 
 	err = s.Unregister("instanceA")
@@ -67,9 +67,9 @@ func TestRegister(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, "unregister failed: error: not found")
 
-	authKey, err = s.Register("instanceA")
+	authToken, err = s.Register("instanceA")
 	require.NoError(t, err)
-	require.Len(t, authKey, DefaultKeyLen)
+	require.Len(t, authToken, DefaultKeyLen)
 }
 
 func TestAuthenticate(t *testing.T) {
@@ -84,14 +84,14 @@ func TestAuthenticate(t *testing.T) {
 	require.Error(t, err)
 	require.EqualError(t, err, "authentication failed: error: not found")
 
-	authKey, err := s.Register("instanceA")
+	authToken, err := s.Register("instanceA")
 	require.NoError(t, err)
-	require.Len(t, authKey, DefaultKeyLen)
+	require.Len(t, authToken, DefaultKeyLen)
 
-	err = s.Authenticate("instanceA", authKey)
+	err = s.Authenticate("instanceA", authToken)
 	require.NoError(t, err)
 
-	err = s.Authenticate("instanceA", authKey+" ")
+	err = s.Authenticate("instanceA", authToken+" ")
 	require.Error(t, err)
 	require.EqualError(t, err, "authentication failed")
 

--- a/service/auth_test.go
+++ b/service/auth_test.go
@@ -29,7 +29,10 @@ func TestRegisterClient(t *testing.T) {
 	})
 
 	t.Run("bad request", func(t *testing.T) {
-		resp, err := http.Post(th.apiURL+"/register", "application/json", bytes.NewBuffer(nil))
+		req, err := http.NewRequest("POST", th.apiURL+"/register", bytes.NewBuffer(nil))
+		require.NoError(t, err)
+		req.SetBasicAuth("", th.srvc.cfg.API.Admin.SecretKey)
+		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusBadRequest, resp.StatusCode)
 		defer resp.Body.Close()
@@ -37,7 +40,10 @@ func TestRegisterClient(t *testing.T) {
 
 	t.Run("valid response", func(t *testing.T) {
 		buf := bytes.NewBuffer([]byte(`{"clientID": "clientA"}`))
-		resp, err := http.Post(th.apiURL+"/register", "application/json", buf)
+		req, err := http.NewRequest("POST", th.apiURL+"/register", buf)
+		require.NoError(t, err)
+		req.SetBasicAuth("", th.srvc.cfg.API.Admin.SecretKey)
+		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 		defer resp.Body.Close()
@@ -76,7 +82,10 @@ func TestWSAuthHandler(t *testing.T) {
 	t.Run("valid auth", func(t *testing.T) {
 		clientID := "clientA"
 		buf := bytes.NewBuffer([]byte(fmt.Sprintf(`{"clientID": "%s"}`, clientID)))
-		resp, err := http.Post(th.apiURL+"/register", "application/json", buf)
+		req, err := http.NewRequest("POST", th.apiURL+"/register", buf)
+		require.NoError(t, err)
+		req.SetBasicAuth("", th.srvc.cfg.API.Admin.SecretKey)
+		resp, err := http.DefaultClient.Do(req)
 		require.NoError(t, err)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 		defer resp.Body.Close()

--- a/service/client.go
+++ b/service/client.go
@@ -1,0 +1,243 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/mattermost/rtcd/service/ws"
+)
+
+const (
+	msgChSize = 64
+)
+
+type Client struct {
+	cfg *ClientConfig
+
+	httpClient *http.Client
+	wsClient   *ws.Client
+	receiveCh  chan ClientMessage
+	errorCh    chan error
+}
+
+func NewClient(cfg ClientConfig) (*Client, error) {
+	var c Client
+
+	if err := cfg.Parse(); err != nil {
+		return nil, fmt.Errorf("failed to parse config: %w", err)
+	}
+	c.cfg = &cfg
+
+	transport := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   5 * time.Second,
+			KeepAlive: 30 * time.Second,
+			DualStack: true,
+		}).DialContext,
+		MaxConnsPerHost:       100,
+		MaxIdleConns:          100,
+		MaxIdleConnsPerHost:   100,
+		ResponseHeaderTimeout: 10 * time.Second,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   1 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+	}
+
+	c.httpClient = &http.Client{Transport: transport}
+
+	return &c, nil
+}
+
+func (c *Client) Register(clientID string) (string, error) {
+	if c.httpClient == nil {
+		return "", fmt.Errorf("http client is not initialized")
+	}
+
+	reqData := map[string]string{
+		"clientID": clientID,
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(reqData); err != nil {
+		return "", fmt.Errorf("failed to encode body: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", c.cfg.httpURL+"/register", &buf)
+	if err != nil {
+		return "", fmt.Errorf("failed to build request: %w", err)
+	}
+	req.SetBasicAuth(c.cfg.ClientID, c.cfg.AuthKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	respData := map[string]string{}
+	if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+		return "", fmt.Errorf("decoding http response failed: %w", err)
+	}
+
+	if resp.StatusCode != http.StatusCreated {
+		if errMsg := respData["error"]; errMsg != "" {
+			return "", fmt.Errorf("request failed: %s", errMsg)
+		}
+		return "", fmt.Errorf("request failed with status %s", resp.Status)
+	}
+
+	authKey := respData["authKey"]
+	if authKey == "" {
+		return "", fmt.Errorf("unexpected empty auth key")
+	}
+
+	return authKey, nil
+}
+
+func (c *Client) Unregister(clientID string) error {
+	if c.httpClient == nil {
+		return fmt.Errorf("http client is not initialized")
+	}
+
+	reqData := map[string]string{
+		"clientID": clientID,
+	}
+
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(reqData); err != nil {
+		return fmt.Errorf("failed to encode body: %w", err)
+	}
+
+	req, err := http.NewRequest("POST", c.cfg.httpURL+"/unregister", &buf)
+	if err != nil {
+		return fmt.Errorf("failed to build request: %w", err)
+	}
+	req.SetBasicAuth(c.cfg.ClientID, c.cfg.AuthKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("http request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		respData := map[string]string{}
+		if err := json.NewDecoder(resp.Body).Decode(&respData); err != nil {
+			return fmt.Errorf("decoding http response failed: %w", err)
+		}
+
+		if errMsg := respData["error"]; errMsg != "" {
+			return fmt.Errorf("request failed: %s", errMsg)
+		}
+		return fmt.Errorf("request failed with status %s", resp.Status)
+	}
+
+	return nil
+}
+
+func (c *Client) Connect() error {
+	if c.wsClient != nil {
+		return fmt.Errorf("ws client is already initialized")
+	}
+
+	wsClient, err := ws.NewClient(ws.ClientConfig{
+		URL:       c.cfg.wsURL,
+		AuthToken: base64.StdEncoding.EncodeToString([]byte(c.cfg.ClientID + ":" + c.cfg.AuthKey)),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create ws client: %w", err)
+	}
+
+	c.wsClient = wsClient
+	c.receiveCh = make(chan ClientMessage, msgChSize)
+	c.errorCh = make(chan error)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		c.msgReader()
+	}()
+
+	go func() {
+		for err := range c.wsClient.ErrorCh() {
+			c.sendError(err)
+		}
+		wg.Wait()
+		close(c.errorCh)
+	}()
+
+	return nil
+}
+
+func (c *Client) Send(msg ClientMessage) error {
+	if c.wsClient == nil {
+		return fmt.Errorf("ws client is not initialized")
+	}
+
+	data, err := msg.Pack()
+	if err != nil {
+		return fmt.Errorf("failed to pack message: %w", err)
+	}
+	return c.wsClient.Send(ws.BinaryMessage, data)
+}
+
+func (c *Client) ReceiveCh() <-chan ClientMessage {
+	return c.receiveCh
+}
+
+func (c *Client) ErrorCh() <-chan error {
+	return c.errorCh
+}
+
+func (c *Client) Close() error {
+	if c.httpClient != nil {
+		c.httpClient.CloseIdleConnections()
+	}
+	if c.wsClient != nil {
+		err := c.wsClient.Close()
+		close(c.receiveCh)
+		return err
+	}
+	return nil
+}
+
+func (c *Client) sendError(err error) {
+	select {
+	case c.errorCh <- err:
+	default:
+		log.Printf("failed to send error: channel is full")
+	}
+}
+
+func (c *Client) msgReader() {
+	for msg := range c.wsClient.ReceiveCh() {
+		if msg.Type != ws.BinaryMessage {
+			c.sendError(fmt.Errorf("unexpected msg type: %d", msg.Type))
+			continue
+		}
+
+		var cm ClientMessage
+		if err := cm.Unpack(msg.Data); err != nil {
+			c.sendError(fmt.Errorf("failed to unpack message: %w", err))
+			continue
+		}
+
+		select {
+		case c.receiveCh <- cm:
+		default:
+			c.sendError(fmt.Errorf("failed to send client message: channel is full"))
+		}
+	}
+}

--- a/service/client_msg_test.go
+++ b/service/client_msg_test.go
@@ -6,6 +6,8 @@ package service
 import (
 	"testing"
 
+	"github.com/mattermost/rtcd/service/rtc"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,28 +22,49 @@ func TestClientMessage(t *testing.T) {
 		require.Equal(t, msg, msg2)
 	})
 
-	t.Run("with type", func(t *testing.T) {
-		msg := NewClientMessage(ClientMessageSDP, nil)
+	t.Run("with join type", func(t *testing.T) {
+		msgData := map[string]string{
+			"connID": "conn_id",
+		}
+		msg := NewClientMessage(ClientMessageJoin, msgData)
 		data, err := msg.Pack()
 		require.NoError(t, err)
-		msg2 := NewClientMessage(ClientMessageSDP, nil)
+		msg2 := NewClientMessage(ClientMessageJoin, msgData)
 		err = msg2.Unpack(data)
 		require.NoError(t, err)
 		require.Equal(t, msg, msg2)
-		require.Equal(t, ClientMessageSDP, msg2.Type)
+		require.Equal(t, ClientMessageJoin, msg2.Type)
 	})
 
-	t.Run("with type and data", func(t *testing.T) {
-		msgData := map[string]interface{}{}
-		msgData["sdp"] = `{"some": "data"}`
-		msg := NewClientMessage(ClientMessageSDP, msgData)
+	t.Run("with leave type", func(t *testing.T) {
+		msgData := map[string]string{
+			"sessionID": "session_id",
+		}
+		msg := NewClientMessage(ClientMessageLeave, msgData)
 		data, err := msg.Pack()
 		require.NoError(t, err)
-		msg2 := NewClientMessage(ClientMessageSDP, msgData)
+		msg2 := NewClientMessage(ClientMessageLeave, msgData)
 		err = msg2.Unpack(data)
 		require.NoError(t, err)
 		require.Equal(t, msg, msg2)
-		require.Equal(t, ClientMessageSDP, msg2.Type)
-		require.Equal(t, msgData, msg2.Data)
+		require.Equal(t, ClientMessageLeave, msg2.Type)
+	})
+
+	t.Run("with rtc type", func(t *testing.T) {
+		rtcMsg := rtc.Message{
+			SessionID: "session_id",
+			GroupID:   "group_id",
+			Type:      rtc.SDPMessage,
+			Data:      []byte(`sdp data`),
+		}
+		msg := NewClientMessage(ClientMessageRTC, rtcMsg)
+		data, err := msg.Pack()
+		require.NoError(t, err)
+		msg2 := &ClientMessage{}
+		err = msg2.Unpack(data)
+		require.NoError(t, err)
+		require.Equal(t, msg, msg2)
+		require.Equal(t, ClientMessageRTC, msg2.Type)
+		require.Equal(t, rtcMsg, msg2.Data)
 	})
 }

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -1,0 +1,302 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/mattermost/rtcd/service/ws"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewClient(t *testing.T) {
+	t.Run("empty config", func(t *testing.T) {
+		c, err := NewClient(ClientConfig{})
+		require.Error(t, err)
+		require.Equal(t, "failed to parse config: invalid URL value: should not be empty", err.Error())
+		require.Nil(t, c)
+	})
+
+	t.Run("invalid url", func(t *testing.T) {
+		c, err := NewClient(ClientConfig{URL: "not_a_url"})
+		require.Error(t, err)
+		require.Equal(t, "failed to parse config: invalid url host: should not be empty", err.Error())
+		require.Nil(t, c)
+	})
+
+	t.Run("invalid scheme", func(t *testing.T) {
+		c, err := NewClient(ClientConfig{URL: "ftp://invalid"})
+		require.Error(t, err)
+		require.Equal(t, `failed to parse config: invalid url scheme: "ftp" is not valid`, err.Error())
+		require.Nil(t, c)
+	})
+
+	t.Run("success http scheme", func(t *testing.T) {
+		apiURL := "http://localhost"
+		c, err := NewClient(ClientConfig{URL: apiURL})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		require.NotEmpty(t, c)
+		require.Equal(t, apiURL, c.cfg.httpURL)
+		require.Equal(t, "ws://localhost/ws", c.cfg.wsURL)
+	})
+
+	t.Run("success https scheme", func(t *testing.T) {
+		apiURL := "https://localhost"
+		c, err := NewClient(ClientConfig{URL: apiURL})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		require.NotEmpty(t, c)
+		require.Equal(t, apiURL, c.cfg.httpURL)
+		require.Equal(t, "wss://localhost/ws", c.cfg.wsURL)
+	})
+}
+
+func TestClientRegister(t *testing.T) {
+	th := SetupTestHelper(t)
+	defer th.Teardown()
+
+	c, err := NewClient(ClientConfig{
+		URL:     th.apiURL,
+		AuthKey: th.srvc.cfg.API.Admin.SecretKey,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	defer c.Close()
+
+	t.Run("empty clientID", func(t *testing.T) {
+		authToken, err := c.Register("")
+		require.Error(t, err)
+		require.Empty(t, authToken)
+		require.Equal(t, "request failed: registration failed: error: empty key", err.Error())
+	})
+
+	t.Run("valid clientID", func(t *testing.T) {
+		authToken, err := c.Register("clientA")
+		require.NoError(t, err)
+		require.NotEmpty(t, authToken)
+	})
+
+	t.Run("existing clientID", func(t *testing.T) {
+		authToken, err := c.Register("clientA")
+		require.Error(t, err)
+		require.Empty(t, authToken)
+		require.Equal(t, "request failed: registration failed: already registered", err.Error())
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		c, err := NewClient(ClientConfig{
+			URL:     th.apiURL,
+			AuthKey: th.srvc.cfg.API.Admin.SecretKey + "_",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		defer c.Close()
+
+		authToken, err := c.Register("")
+		require.Error(t, err)
+		require.Empty(t, authToken)
+		require.Equal(t, "request failed: unauthorized", err.Error())
+	})
+
+}
+
+func TestClientUnregister(t *testing.T) {
+	th := SetupTestHelper(t)
+	defer th.Teardown()
+
+	c, err := NewClient(ClientConfig{
+		URL:     th.apiURL,
+		AuthKey: th.srvc.cfg.API.Admin.SecretKey,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+	defer c.Close()
+
+	t.Run("empty client ID", func(t *testing.T) {
+		authKey, err := c.Register("clientA")
+		require.NoError(t, err)
+		require.NotEmpty(t, authKey)
+
+		err = c.Unregister("")
+		require.Error(t, err)
+		require.Equal(t, "request failed: client id should not be empty", err.Error())
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		err := c.Unregister("clientB")
+		require.Error(t, err)
+		require.Equal(t, "request failed: unregister failed: error: not found", err.Error())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		err := c.Unregister("clientA")
+		require.NoError(t, err)
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		c, err := NewClient(ClientConfig{
+			URL:     th.apiURL,
+			AuthKey: th.srvc.cfg.API.Admin.SecretKey + "_",
+		})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		defer c.Close()
+
+		err = c.Unregister("clientA")
+		require.Error(t, err)
+		require.Equal(t, "request failed: unauthorized", err.Error())
+	})
+}
+
+func TestClientConnect(t *testing.T) {
+	th := SetupTestHelper(t)
+	defer th.Teardown()
+
+	c, err := NewClient(ClientConfig{URL: th.apiURL})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	t.Run("auth failure", func(t *testing.T) {
+		err := c.Connect()
+		require.Error(t, err)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		clientID := "clientA"
+		authKey, err := th.adminClient.Register(clientID)
+		require.NoError(t, err)
+		require.NotEmpty(t, authKey)
+
+		c.cfg.ClientID = clientID
+		c.cfg.AuthKey = authKey
+
+		err = c.Connect()
+		require.NoError(t, err)
+
+		err = c.Connect()
+		require.Error(t, err)
+		require.Equal(t, "ws client is already initialized", err.Error())
+
+		err = c.Close()
+		require.NoError(t, err)
+	})
+}
+
+func TestClientSend(t *testing.T) {
+	th := SetupTestHelper(t)
+	defer th.Teardown()
+
+	clientID := "clientA"
+	authKey, err := th.adminClient.Register(clientID)
+	require.NoError(t, err)
+	require.NotEmpty(t, authKey)
+
+	t.Run("not ininitialized", func(t *testing.T) {
+		c, err := NewClient(ClientConfig{
+			URL:      th.apiURL,
+			ClientID: clientID,
+			AuthKey:  authKey,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+		defer c.Close()
+
+		err = c.Send(ClientMessage{})
+		require.Error(t, err)
+		require.Equal(t, "ws client is not initialized", err.Error())
+	})
+
+	t.Run("success", func(t *testing.T) {
+		c, err := NewClient(ClientConfig{
+			URL:      th.apiURL,
+			ClientID: clientID,
+			AuthKey:  authKey,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, c)
+
+		err = c.Connect()
+		require.NoError(t, err)
+
+		var wg sync.WaitGroup
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			err := <-c.ErrorCh()
+			require.NoError(t, err)
+		}()
+
+		for i := 0; i < 10; i++ {
+			cm := ClientMessage{
+				Type: "msgType",
+				Data: []byte(`data`),
+			}
+			err := c.Send(cm)
+			require.NoError(t, err)
+		}
+
+		err = c.Close()
+		require.NoError(t, err)
+		wg.Wait()
+	})
+}
+
+func TestClientReceive(t *testing.T) {
+	th := SetupTestHelper(t)
+	defer th.Teardown()
+
+	clientID := "clientA"
+	authKey, err := th.adminClient.Register(clientID)
+	require.NoError(t, err)
+	require.NotEmpty(t, authKey)
+
+	c, err := NewClient(ClientConfig{
+		URL:      th.apiURL,
+		ClientID: clientID,
+		AuthKey:  authKey,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	err = c.Connect()
+	require.NoError(t, err)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	go func() {
+		defer wg.Done()
+		err := <-c.ErrorCh()
+		require.NoError(t, err)
+	}()
+
+	msgs := []ClientMessage{
+		{Type: "test"},
+		{Type: "test2"},
+		{Type: "test3"},
+	}
+
+	go func() {
+		defer wg.Done()
+		i := 0
+		for msg := range c.ReceiveCh() {
+			require.Equal(t, msgs[i], msg)
+			i++
+		}
+	}()
+
+	for _, msg := range msgs {
+		data, err := msg.Pack()
+		require.NoError(t, err)
+		err = th.srvc.wsServer.Send(ws.Message{Type: ws.BinaryMessage, Data: data})
+		require.NoError(t, err)
+	}
+
+	err = c.Close()
+	require.NoError(t, err)
+	wg.Wait()
+}

--- a/service/config.go
+++ b/service/config.go
@@ -5,15 +5,64 @@ package service
 
 import (
 	"fmt"
+	"net/url"
 
 	"github.com/mattermost/rtcd/service/api"
 	"github.com/mattermost/rtcd/service/rtc"
 )
 
+type AdminConfig struct {
+	// Whether or not to enable admin API access.
+	Enable bool `toml:"enable"`
+	// The secret key used to authenticate admin requests.
+	SecretKey string `toml:"secret_key"`
+}
+
+func (c AdminConfig) IsValid() error {
+	if !c.Enable {
+		return nil
+	}
+
+	if c.SecretKey == "" {
+		return fmt.Errorf("invalid SecretKey value: should not be empty")
+	}
+
+	return nil
+}
+
+type APIConfig struct {
+	HTTP  api.Config  `toml:"http"`
+	Admin AdminConfig `toml:"admin"`
+}
+
 type Config struct {
-	API   api.Config
+	API   APIConfig
 	RTC   rtc.ServerConfig
 	Store StoreConfig
+}
+
+func (c APIConfig) IsValid() error {
+	if err := c.Admin.IsValid(); err != nil {
+		return fmt.Errorf("failed to validate admin config: %w", err)
+	}
+
+	if err := c.HTTP.IsValid(); err != nil {
+		return fmt.Errorf("failed to validate http config: %w", err)
+	}
+
+	return nil
+}
+
+func (c Config) IsValid() error {
+	if err := c.API.IsValid(); err != nil {
+		return err
+	}
+
+	if err := c.Store.IsValid(); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 type StoreConfig struct {
@@ -27,13 +76,42 @@ func (c StoreConfig) IsValid() error {
 	return nil
 }
 
-func (c Config) IsValid() error {
-	if err := c.API.IsValid(); err != nil {
-		return err
+type ClientConfig struct {
+	httpURL string
+	wsURL   string
+
+	ClientID string
+	AuthKey  string
+	URL      string
+}
+
+func (c *ClientConfig) Parse() error {
+	if c.URL == "" {
+		return fmt.Errorf("invalid URL value: should not be empty")
 	}
 
-	if err := c.Store.IsValid(); err != nil {
-		return err
+	u, err := url.Parse(c.URL)
+	if err != nil {
+		return fmt.Errorf("failed to parse url: %w", err)
+	}
+
+	if u.Host == "" {
+		return fmt.Errorf("invalid url host: should not be empty")
+	}
+
+	switch u.Scheme {
+	case "http":
+		c.httpURL = c.URL
+		u.Scheme = "ws"
+		u.Path = "/ws"
+		c.wsURL = u.String()
+	case "https":
+		c.httpURL = c.URL
+		u.Scheme = "wss"
+		u.Path = "/ws"
+		c.wsURL = u.String()
+	default:
+		return fmt.Errorf("invalid url scheme: %q is not valid", u.Scheme)
 	}
 
 	return nil

--- a/service/config_test.go
+++ b/service/config_test.go
@@ -1,0 +1,91 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminConfigIsValid(t *testing.T) {
+	t.Run("empty struct", func(t *testing.T) {
+		var cfg AdminConfig
+		err := cfg.IsValid()
+		require.NoError(t, err)
+	})
+
+	t.Run("empty key", func(t *testing.T) {
+		var cfg AdminConfig
+		cfg.Enable = true
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.Equal(t, "invalid SecretKey value: should not be empty", err.Error())
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		var cfg AdminConfig
+		cfg.Enable = true
+		cfg.SecretKey = "secret_key"
+		err := cfg.IsValid()
+		require.NoError(t, err)
+	})
+}
+
+func TestStoreConfigIsValid(t *testing.T) {
+	t.Run("empty struct", func(t *testing.T) {
+		var cfg StoreConfig
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.Equal(t, "invalid DataSource value: should not be empty", err.Error())
+	})
+
+	t.Run("valid", func(t *testing.T) {
+		var cfg StoreConfig
+		cfg.DataSource = "/tmp/rtcd_db"
+		err := cfg.IsValid()
+		require.NoError(t, err)
+	})
+}
+
+func TestClientConfigParse(t *testing.T) {
+	t.Run("empty struct", func(t *testing.T) {
+		var cfg ClientConfig
+		err := cfg.Parse()
+		require.Error(t, err)
+		require.Equal(t, "invalid URL value: should not be empty", err.Error())
+	})
+
+	t.Run("invalid URL", func(t *testing.T) {
+		var cfg ClientConfig
+		cfg.URL = "//sd"
+		err := cfg.Parse()
+		require.Error(t, err)
+		require.Equal(t, `invalid url scheme: "" is not valid`, err.Error())
+	})
+
+	t.Run("missing host", func(t *testing.T) {
+		var cfg ClientConfig
+		cfg.URL = "https:///test"
+		err := cfg.Parse()
+		require.Error(t, err)
+		require.Equal(t, "invalid url host: should not be empty", err.Error())
+	})
+
+	t.Run("valid http", func(t *testing.T) {
+		var cfg ClientConfig
+		cfg.URL = "http://rtcd.example.com"
+		err := cfg.Parse()
+		require.NoError(t, err)
+		require.Equal(t, "ws://rtcd.example.com/ws", cfg.wsURL)
+	})
+
+	t.Run("valid https", func(t *testing.T) {
+		var cfg ClientConfig
+		cfg.URL = "https://rtcd.example.com"
+		err := cfg.Parse()
+		require.NoError(t, err)
+		require.Equal(t, "wss://rtcd.example.com/ws", cfg.wsURL)
+	})
+}

--- a/service/rtc/msg.go
+++ b/service/rtc/msg.go
@@ -22,14 +22,15 @@ const (
 )
 
 type Message struct {
-	Session SessionConfig
-	Type    MessageType
-	Data    []byte
+	GroupID   string      `msgpack:"group_id"`
+	SessionID string      `msgpack:"session_id"`
+	Type      MessageType `msgpack:"type"`
+	Data      []byte      `msgpack:"data,omitempty"`
 }
 
 func (m *Message) IsValid() error {
-	if err := m.Session.IsValid(); err != nil {
-		return err
+	if m.SessionID == "" {
+		return fmt.Errorf("invalid SessionID value: should not be empty")
 	}
 	if m.Type == 0 {
 		return fmt.Errorf("invalid Type value")
@@ -40,9 +41,10 @@ func (m *Message) IsValid() error {
 
 func newMessage(s *session, msgType MessageType, data []byte) Message {
 	return Message{
-		Session: s.cfg,
-		Type:    ICEMessage,
-		Data:    data,
+		GroupID:   s.cfg.GroupID,
+		SessionID: s.cfg.SessionID,
+		Type:      ICEMessage,
+		Data:      data,
 	}
 }
 

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -82,6 +82,9 @@ func (s *Server) addSession(cfg SessionConfig, peerConn *webrtc.PeerConnection) 
 	if !ok {
 		return nil, fmt.Errorf("user session already exists")
 	}
+	s.mut.Lock()
+	s.sessions[cfg.SessionID] = cfg
+	s.mut.Unlock()
 
 	return us, nil
 }

--- a/service/rtc/session_test.go
+++ b/service/rtc/session_test.go
@@ -48,7 +48,7 @@ func TestAddSession(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, us)
 
-		err = server.CloseSession(cfg)
+		err = server.CloseSession(cfg.SessionID)
 		require.NoError(t, err)
 	})
 }

--- a/service/ws/msg.go
+++ b/service/ws/msg.go
@@ -16,21 +16,24 @@ const (
 
 // Message defines the data to be sent to or received from a ws connection.
 type Message struct {
-	ConnID string
-	Type   MessageType
-	Data   []byte
+	ClientID string
+	ConnID   string
+	Type     MessageType
+	Data     []byte
 }
 
-func newOpenMessage(connID string) Message {
+func newOpenMessage(connID, clientID string) Message {
 	return Message{
-		ConnID: connID,
-		Type:   OpenMessage,
+		ClientID: clientID,
+		ConnID:   connID,
+		Type:     OpenMessage,
 	}
 }
 
-func newCloseMessage(connID string) Message {
+func newCloseMessage(connID, clientID string) Message {
 	return Message{
-		ConnID: connID,
-		Type:   CloseMessage,
+		ClientID: clientID,
+		ConnID:   connID,
+		Type:     CloseMessage,
 	}
 }

--- a/service/ws/server_test.go
+++ b/service/ws/server_test.go
@@ -221,7 +221,7 @@ func TestGetConn(t *testing.T) {
 	require.Empty(t, s.conns)
 
 	t.Run("missing", func(t *testing.T) {
-		c := s.getConn(random.NewID())
+		c := s.getConn(random.NewID(), "")
 		require.Nil(t, c)
 	})
 
@@ -233,7 +233,7 @@ func TestGetConn(t *testing.T) {
 		require.NotNil(t, s.conns[conn.id])
 		require.Equal(t, conn, s.conns[conn.id])
 
-		c := s.getConn(conn.id)
+		c := s.getConn(conn.id, "")
 		require.NotNil(t, c)
 		require.Equal(t, conn, c)
 
@@ -242,8 +242,29 @@ func TestGetConn(t *testing.T) {
 		require.Empty(t, s.conns)
 	})
 
+	t.Run("by client id", func(t *testing.T) {
+		clientID := random.NewID()
+		conn := newConn(random.NewID(), clientID, &websocket.Conn{})
+		ok := s.addConn(conn)
+		require.True(t, ok)
+		require.Len(t, s.conns, 1)
+		require.NotNil(t, s.conns[conn.id])
+		require.Equal(t, conn, s.conns[conn.id])
+
+		c := s.getConn("", clientID)
+		require.NotNil(t, c)
+		require.Equal(t, conn, c)
+
+		ok = s.removeConn(c.id)
+		require.True(t, ok)
+		require.Empty(t, s.conns)
+
+		c = s.getConn("", clientID)
+		require.Nil(t, c)
+	})
+
 	t.Run("removed", func(t *testing.T) {
-		c := s.getConn(random.NewID())
+		c := s.getConn(random.NewID(), "")
 		require.Nil(t, c)
 
 		conn := newConn(random.NewID(), random.NewID(), &websocket.Conn{})
@@ -257,7 +278,7 @@ func TestGetConn(t *testing.T) {
 		require.True(t, ok)
 		require.Empty(t, s.conns)
 
-		c = s.getConn(random.NewID())
+		c = s.getConn(random.NewID(), "")
 		require.Nil(t, c)
 	})
 }
@@ -301,6 +322,51 @@ func TestGetConns(t *testing.T) {
 	conns = s.getConns()
 	require.Equal(t, len(s.conns), len(conns))
 	require.ElementsMatch(t, []*conn{conn1, conn2, conn3}, conns)
+}
+
+func TestGetClientConns(t *testing.T) {
+	s, _, shutdown := setupServer(t)
+	defer shutdown()
+	defer func() {
+		// cleanup
+		s.mut.Lock()
+		defer s.mut.Unlock()
+		for id := range s.conns {
+			delete(s.conns, id)
+		}
+	}()
+
+	clientID := random.NewID()
+	conns := s.getClientConns(clientID)
+	require.Empty(t, conns)
+
+	conn1 := newConn(random.NewID(), random.NewID(), &websocket.Conn{})
+	ok := s.addConn(conn1)
+	require.True(t, ok)
+
+	conns = s.getClientConns(clientID)
+	require.Empty(t, conns)
+
+	conn2 := newConn(random.NewID(), clientID, &websocket.Conn{})
+	ok = s.addConn(conn2)
+	require.True(t, ok)
+
+	conns = s.getClientConns(clientID)
+	require.NotEmpty(t, conns)
+	require.Equal(t, conn2, conns[0])
+
+	conn3 := newConn(random.NewID(), clientID, &websocket.Conn{})
+	ok = s.addConn(conn3)
+	require.True(t, ok)
+
+	conns = s.getClientConns(clientID)
+	require.Contains(t, conns, conn2, conn3)
+
+	ok = s.removeConn(conn3.id)
+	require.True(t, ok)
+
+	conns = s.getClientConns(clientID)
+	require.Equal(t, conn2, conns[0])
 }
 
 func TestWithAuthCb(t *testing.T) {
@@ -377,7 +443,7 @@ func TestRaceReceiveClose(t *testing.T) {
 		defer wg.Done()
 		defer c1.Close()
 		for i := 0; i < 100; i++ {
-			c1.Send(TextMessage, []byte("conn data"))
+			_ = c1.Send(TextMessage, []byte("conn data"))
 		}
 	}()
 
@@ -386,7 +452,7 @@ func TestRaceReceiveClose(t *testing.T) {
 		defer wg.Done()
 		defer c2.Close()
 		for i := 0; i < 100; i++ {
-			c2.Send(TextMessage, []byte("conn data"))
+			_ = c2.Send(TextMessage, []byte("conn data"))
 		}
 	}()
 
@@ -453,7 +519,7 @@ func TestSendMessages(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < 100; i++ {
-			s.SendCh() <- Message{
+			s.sendCh <- Message{
 				ConnID: conns[0].id,
 				Data:   []byte("some data"),
 				Type:   TextMessage,


### PR DESCRIPTION
#### Summary

This is the last piece of implementation that lets Calls plugin instances successfully interface with the service over network.
PR implements a `service.Client` to use the provided HTTP/WebSocket API.

Bear in mind that the sole purpose of this PR is establishing main functionality (getting calls to work). There isn't any real improvement (e.g. reconnection support) just yet. Also, APIs are very likely to break for some time still as we are trying to come up with a proper solution on the security front.

Companion PR is https://github.com/mattermost/mattermost-plugin-calls/pull/41