### PR TITLE
[MM-43391] Use defaults if config file is missing

### DIFF
--- a/cmd/rtcd/config.go
+++ b/cmd/rtcd/config.go
@@ -4,7 +4,10 @@
 package main
 
 import (
+	"errors"
 	"fmt"
+	"log"
+	"os"
 
 	"github.com/mattermost/rtcd/logger"
 	"github.com/mattermost/rtcd/service"
@@ -28,12 +31,29 @@ func (c Config) IsValid() error {
 	return nil
 }
 
+func (c *Config) SetDefaults() {
+	c.Service.API.HTTP.ListenAddress = ":8045"
+	c.Service.RTC.ICEPortUDP = 8443
+	c.Service.Store.DataSource = "/tmp/rtcd_db"
+	c.Logger.EnableConsole = true
+	c.Logger.ConsoleJSON = false
+	c.Logger.ConsoleLevel = "INFO"
+	c.Logger.EnableFile = true
+	c.Logger.FileJSON = true
+	c.Logger.FileLocation = "rtcd.log"
+	c.Logger.FileLevel = "DEBUG"
+	c.Logger.EnableColor = false
+}
+
 // loadConfig reads the config file and returns a new Config,
 // This method overrides values in the file if there is any environment
 // variables corresponding to a specific setting.
 func loadConfig(path string) (Config, error) {
 	var cfg Config
-	if _, err := toml.DecodeFile(path, &cfg); err != nil {
+	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
+		log.Printf("config file not found at %s, using defaults", path)
+		cfg.SetDefaults()
+	} else if _, err := toml.DecodeFile(path, &cfg); err != nil {
 		return cfg, fmt.Errorf("failed to decode config file: %w", err)
 	}
 	if err := envconfig.Process("rtcd", &cfg); err != nil {

--- a/cmd/rtcd/config_test.go
+++ b/cmd/rtcd/config_test.go
@@ -13,9 +13,12 @@ import (
 
 func TestLoadConfig(t *testing.T) {
 	t.Run("non existant file", func(t *testing.T) {
+		var testCfg Config
+		testCfg.SetDefaults()
 		cfg, err := loadConfig("")
-		require.Error(t, err)
-		require.Empty(t, cfg)
+		require.NoError(t, err)
+		require.NotEmpty(t, cfg)
+		require.Equal(t, testCfg, cfg)
 	})
 
 	t.Run("empty file", func(t *testing.T) {


### PR DESCRIPTION
#### Summary

Letting the service use defaults if the config file is missing. This makes the service run even if not provided with a config file and removes the necessity of including such file in the docker image.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43391