### PR TITLE
[MM-43394] Document config environment overrides

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,5 +29,9 @@ build:
 	mkdir -p dist
 	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/rtcd -ldflags '$(LDFLAGS)' -mod=readonly -trimpath ./cmd/rtcd
 
+.PHONY: doc
+doc:
+	go run ./scripts/env_config.go ./docs/env_config.md
+
 clean:
 	rm -rf dist

--- a/cmd/rtcd/config.go
+++ b/cmd/rtcd/config.go
@@ -9,47 +9,17 @@ import (
 	"log"
 	"os"
 
-	"github.com/mattermost/rtcd/logger"
 	"github.com/mattermost/rtcd/service"
 
 	"github.com/BurntSushi/toml"
 	"github.com/kelseyhightower/envconfig"
 )
 
-type Config struct {
-	Service service.Config
-	Logger  logger.Config
-}
-
-func (c Config) IsValid() error {
-	if err := c.Service.IsValid(); err != nil {
-		return err
-	}
-	if err := c.Logger.IsValid(); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (c *Config) SetDefaults() {
-	c.Service.API.HTTP.ListenAddress = ":8045"
-	c.Service.RTC.ICEPortUDP = 8443
-	c.Service.Store.DataSource = "/tmp/rtcd_db"
-	c.Logger.EnableConsole = true
-	c.Logger.ConsoleJSON = false
-	c.Logger.ConsoleLevel = "INFO"
-	c.Logger.EnableFile = true
-	c.Logger.FileJSON = true
-	c.Logger.FileLocation = "rtcd.log"
-	c.Logger.FileLevel = "DEBUG"
-	c.Logger.EnableColor = false
-}
-
 // loadConfig reads the config file and returns a new Config,
 // This method overrides values in the file if there is any environment
 // variables corresponding to a specific setting.
-func loadConfig(path string) (Config, error) {
-	var cfg Config
+func loadConfig(path string) (service.Config, error) {
+	var cfg service.Config
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		log.Printf("config file not found at %s, using defaults", path)
 		cfg.SetDefaults()

--- a/cmd/rtcd/config_test.go
+++ b/cmd/rtcd/config_test.go
@@ -8,12 +8,14 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mattermost/rtcd/service"
+
 	"github.com/stretchr/testify/require"
 )
 
 func TestLoadConfig(t *testing.T) {
 	t.Run("non existant file", func(t *testing.T) {
-		var testCfg Config
+		var testCfg service.Config
 		testCfg.SetDefaults()
 		cfg, err := loadConfig("")
 		require.NoError(t, err)

--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -1,4 +1,4 @@
-[service.api]
+[api]
 http.listen_address = ":8045"
 http.tls.enable = false
 http.tls.cert_file = ""
@@ -6,11 +6,11 @@ http.tls.cert_key = ""
 admin.enable = false
 admin.secret_key = "admin_secret_key"
 
-[service.rtc]
+[rtc]
 ice_port_udp = 8443
 ice_host_override = ""
 
-[service.store]
+[store]
 data_source = "/tmp/rtcd_db"
 
 [logger]

--- a/docs/env_config.md
+++ b/docs/env_config.md
@@ -1,0 +1,22 @@
+### Config Environment Overrides
+
+```
+KEY                            TYPE
+RTCD_API_HTTP_LISTENADDRESS    String
+RTCD_API_HTTP_TLS_ENABLE       True or False
+RTCD_API_HTTP_TLS_CERTFILE     String
+RTCD_API_HTTP_TLS_CERTKEY      String
+RTCD_API_ADMIN_ENABLE          True or False
+RTCD_API_ADMIN_SECRETKEY       String
+RTCD_RTC_ICEPORTUDP            Integer
+RTCD_RTC_ICEHOSTOVERRIDE       String
+RTCD_STORE_DATASOURCE          String
+RTCD_LOGGER_ENABLECONSOLE      True or False
+RTCD_LOGGER_CONSOLEJSON        True or False
+RTCD_LOGGER_CONSOLELEVEL       String
+RTCD_LOGGER_ENABLEFILE         True or False
+RTCD_LOGGER_FILEJSON           True or False
+RTCD_LOGGER_FILELEVEL          String
+RTCD_LOGGER_FILELOCATION       String
+RTCD_LOGGER_ENABLECOLOR        True or False
+```

--- a/scripts/env_config.go
+++ b/scripts/env_config.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"log"
+	"os"
+	"text/tabwriter"
+
+	"github.com/mattermost/rtcd/service"
+
+	"github.com/kelseyhightower/envconfig"
+)
+
+func main() {
+	if len(os.Args) < 2 {
+		log.Fatalf("unexpected number of arguments, need 1")
+	}
+
+	outFile, err := os.OpenFile(os.Args[1], os.O_RDWR|os.O_CREATE, 0644)
+	if err != nil {
+		log.Fatalf("failed to write file: %s", err.Error())
+	}
+	defer outFile.Close()
+	fmt := "### Config Environment Overrides\n\n```\nKEY	TYPE\n{{range .}}{{usage_key .}}	{{usage_type .}}\n{{end}}```\n"
+	tabs := tabwriter.NewWriter(outFile, 1, 0, 4, ' ', 0)
+	_ = envconfig.Usagef("rtcd", &service.Config{}, tabs, fmt)
+	tabs.Flush()
+}

--- a/service/config.go
+++ b/service/config.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 
+	"github.com/mattermost/rtcd/logger"
 	"github.com/mattermost/rtcd/service/api"
 	"github.com/mattermost/rtcd/service/rtc"
 )
@@ -36,9 +37,10 @@ type APIConfig struct {
 }
 
 type Config struct {
-	API   APIConfig
-	RTC   rtc.ServerConfig
-	Store StoreConfig
+	API    APIConfig
+	RTC    rtc.ServerConfig
+	Store  StoreConfig
+	Logger logger.Config
 }
 
 func (c APIConfig) IsValid() error {
@@ -62,7 +64,25 @@ func (c Config) IsValid() error {
 		return err
 	}
 
+	if err := c.Logger.IsValid(); err != nil {
+		return err
+	}
+
 	return nil
+}
+
+func (c *Config) SetDefaults() {
+	c.API.HTTP.ListenAddress = ":8045"
+	c.RTC.ICEPortUDP = 8443
+	c.Store.DataSource = "/tmp/rtcd_db"
+	c.Logger.EnableConsole = true
+	c.Logger.ConsoleJSON = false
+	c.Logger.ConsoleLevel = "INFO"
+	c.Logger.EnableFile = true
+	c.Logger.FileJSON = true
+	c.Logger.FileLocation = "rtcd.log"
+	c.Logger.FileLevel = "DEBUG"
+	c.Logger.EnableColor = false
 }
 
 type StoreConfig struct {

--- a/service/helper_test.go
+++ b/service/helper_test.go
@@ -8,17 +8,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/mattermost/rtcd/logger"
 	"github.com/mattermost/rtcd/service/api"
 	"github.com/mattermost/rtcd/service/rtc"
 
-	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 	"github.com/stretchr/testify/require"
 )
 
 type TestHelper struct {
 	srvc        *Service
 	adminClient *Client
-	log         *mlog.Logger
 	cfg         Config
 	tb          testing.TB
 	apiURL      string
@@ -49,15 +48,16 @@ func SetupTestHelper(tb testing.TB) *TestHelper {
 			Store: StoreConfig{
 				DataSource: dbDir,
 			},
+			Logger: logger.Config{
+				EnableConsole: true,
+				ConsoleLevel:  "ERROR",
+			},
 		},
 		tb:    tb,
 		dbDir: dbDir,
 	}
 
-	th.log, err = mlog.NewLogger()
-	require.NoError(th.tb, err)
-
-	th.srvc, err = New(th.cfg, th.log)
+	th.srvc, err = New(th.cfg)
 	require.NoError(th.tb, err)
 	require.NotNil(th.tb, th.srvc)
 
@@ -79,10 +79,7 @@ func SetupTestHelper(tb testing.TB) *TestHelper {
 }
 
 func (th *TestHelper) Teardown() {
-	err := th.log.Shutdown()
-	require.NoError(th.tb, err)
-
-	err = th.srvc.Stop()
+	err := th.srvc.Stop()
 	require.NoError(th.tb, err)
 
 	err = os.RemoveAll(th.dbDir)


### PR DESCRIPTION
#### Summary

PR simplifies the configuration by removing an unnecessary level of nesting. This means the logger is now created by the service itself which I think it's acceptable.

As a bonus I've added a new `make doc` command to generate a [list of environment config overrides](https://github.com/mattermost/rtcd/blob/MM-43394/docs/env_config.md). Ideally I'd like to improve it and also document each config setting using tags but that requires far more effort so I am happy to have something rather than nothing for the time being.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43394

/cc @phoinixgrr 