### PR TITLE
High concurrency fixes

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -6,6 +6,7 @@ package service
 import (
 	"fmt"
 	"net/http/pprof"
+	"sync"
 	"time"
 
 	"github.com/mattermost/rtcd/logger"
@@ -28,6 +29,13 @@ type Service struct {
 	auth      *auth.Service
 	metrics   *perf.Metrics
 	log       *mlog.Logger
+
+	// connMap maps user sessions to the websocket connection they originated
+	// from. This is needed to keep track of the MM instance end users are
+	// connected to in order to route any message to it and avoid the additional
+	// intra-cluster messaging layer that can introduce race conditions.
+	connMap map[string]string
+	mut     sync.RWMutex
 }
 
 func New(cfg Config) (*Service, error) {
@@ -38,6 +46,7 @@ func New(cfg Config) (*Service, error) {
 	s := &Service{
 		cfg:     cfg,
 		metrics: perf.NewMetrics("rtcd", nil),
+		connMap: map[string]string{},
 	}
 
 	var err error
@@ -177,6 +186,13 @@ func (s *Service) handleRTCMsg(msg rtc.Message) error {
 		return fmt.Errorf("unexpected rtc message type: %s", cm.Type)
 	}
 
+	s.mut.RLock()
+	connID := s.connMap[msg.SessionID]
+	s.mut.RUnlock()
+	if connID == "" {
+		return fmt.Errorf("unexpected empty connID")
+	}
+
 	cm.Data = msg
 
 	data, err := cm.Pack()
@@ -185,6 +201,7 @@ func (s *Service) handleRTCMsg(msg rtc.Message) error {
 	}
 
 	wsMsg := ws.Message{
+		ConnID:   connID,
 		ClientID: msg.GroupID,
 		Type:     ws.BinaryMessage,
 		Data:     data,
@@ -226,6 +243,7 @@ func (s *Service) handleClientMsg(msg ws.Message) error {
 		if sessionID == "" {
 			return fmt.Errorf("missing sessionID in client message")
 		}
+
 		cfg := rtc.SessionConfig{
 			GroupID:   msg.ClientID,
 			CallID:    callID,
@@ -236,6 +254,11 @@ func (s *Service) handleClientMsg(msg ws.Message) error {
 		if err := s.rtcServer.InitSession(cfg); err != nil {
 			return fmt.Errorf("failed to initialize rtc session: %w", err)
 		}
+
+		s.mut.Lock()
+		s.connMap[sessionID] = msg.ConnID
+		s.mut.Unlock()
+
 		return nil
 	case ClientMessageLeave:
 		data, ok := cm.Data.(map[string]string)
@@ -246,6 +269,11 @@ func (s *Service) handleClientMsg(msg ws.Message) error {
 		if sessionID == "" {
 			return fmt.Errorf("missing sessionID in client message")
 		}
+
+		s.mut.Lock()
+		delete(s.connMap, sessionID)
+		s.mut.Unlock()
+
 		s.log.Debug("leave message", mlog.String("sessionID", sessionID))
 		if err := s.rtcServer.CloseSession(sessionID); err != nil {
 			return fmt.Errorf("failed to close session: %w", err)

--- a/service/service.go
+++ b/service/service.go
@@ -233,11 +233,9 @@ func (s *Service) handleClientMsg(msg ws.Message) error {
 			SessionID: sessionID,
 		}
 		s.log.Debug("join message", mlog.Any("sessionCfg", cfg))
-		go func() {
-			if err := s.rtcServer.InitSession(cfg); err != nil {
-				s.log.Error("failed to initialize rtc session", mlog.Err(err))
-			}
-		}()
+		if err := s.rtcServer.InitSession(cfg); err != nil {
+			return fmt.Errorf("failed to initialize rtc session: %w", err)
+		}
 		return nil
 	case ClientMessageLeave:
 		data, ok := cm.Data.(map[string]string)

--- a/service/ws/conn.go
+++ b/service/ws/conn.go
@@ -4,8 +4,6 @@
 package ws
 
 import (
-	"math/rand"
-
 	"github.com/gorilla/websocket"
 )
 
@@ -56,19 +54,13 @@ func (s *Server) removeConn(connID string) bool {
 	return true
 }
 
-func (s *Server) getConn(connID, clientID string) *conn {
+func (s *Server) getConn(connID string) *conn {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
 	if connID != "" {
 		c := s.conns[connID]
 		return c
-	}
-
-	if clientID != "" {
-		if conns := s.getClientConns(clientID); len(conns) > 0 {
-			return conns[rand.Intn(len(conns))]
-		}
 	}
 
 	return nil
@@ -82,18 +74,6 @@ func (s *Server) getConns() []*conn {
 	for _, conn := range s.conns {
 		conns[i] = conn
 		i++
-	}
-	return conns
-}
-
-func (s *Server) getClientConns(clientID string) []*conn {
-	s.mut.RLock()
-	defer s.mut.RUnlock()
-	var conns []*conn
-	for _, conn := range s.conns {
-		if conn.clientID == clientID {
-			conns = append(conns, conn)
-		}
 	}
 	return conns
 }

--- a/service/ws/server.go
+++ b/service/ws/server.go
@@ -190,7 +190,7 @@ func (s *Server) connWriter() {
 				return
 			}
 
-			conn := s.getConn(msg.ConnID, msg.ClientID)
+			conn := s.getConn(msg.ConnID)
 			if conn == nil {
 				s.log.Error("failed to get conn for sending", mlog.String("connID", msg.ConnID), mlog.String("clientID", msg.ClientID))
 				continue


### PR DESCRIPTION
#### Summary

Addressing two issues that were found during initial performance testing.

- Making `rtc.Server.InitSession()` partially synchronous to avoid a race condition in which events could be processed before the connection they targeted was fully initiated in the state.
- Adding a map to the service to keep track of which MM instance the end users connections (session ids) belong to. This is to avoid WebRTC negotiation errors caused by out of order delivery of websocket messages.
