### PR TITLE
[DOPS-942] Makefile refactor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,17 @@
-config/config.toml
+# Binaries
 dist/
-*.log
+
+# Editors/IDEs
+*.swp
+*.swo
 *.vim
+.vscode/
+~
+
+# Helm
+Chart.lock
+*.tgz
+
+# App Specific
+config/config.toml
+*.log

--- a/Makefile
+++ b/Makefile
@@ -1,52 +1,199 @@
-DEFAULT_GOARCH := $(shell go env GOARCH)
-BUILD_HASH = $(shell git rev-parse HEAD)
-LDFLAGS += -X "github.com/mattermost/rtcd/service.buildHash=$(BUILD_HASH)"
 
-## Check go mod files consistency
-.PHONY: gomod-check
-gomod-check:
-	@echo Checking go mod files consistency
-	go mod tidy -v && git --no-pager diff --exit-code go.mod go.sum || (echo "Please run \"go mod tidy\" and commit the changes in go.mod and go.sum." && exit 1)
+# Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+# See LICENSE for license information.
 
-.PHONY: check-style
-check-style: golangci-lint gomod-check
-	@echo Checking for style guide compliance
+# ====================================================================================
+# Variables
 
-.PHONY: golangci-lint
-golangci-lint: ## Run golangci-lint on codebase
-# https://stackoverflow.com/a/677212/1027058 (check if a command exists or not)
-	@if ! [ -x "$$(command -v golangci-lint)" ]; then \
-		echo "golangci-lint is not installed. Please see https://github.com/golangci/golangci-lint#install for installation instructions."; \
-		exit 1; \
-	fi; \
+# App Code location
+CONFIG_APP_CODE         += ./cmd/rtcd
 
-	@echo Running golangci-lint
-	golangci-lint run ./...
+## Docker Variables
+# Docker executable
+DOCKER                  := $(shell which docker)
+# Dockerfile's location
+DOCKER_FILE             += ./build/Dockerfile
+# Docker options to inherit for all docker run commands
+DOCKER_OPTS             += --rm -i -u $$(id -u):$$(id -g) --platform "linux/amd64"
+# Registry to upload images
+DOCKER_REGISTRY         += docker.io
+DOCKER_REGISTRY_REPO    += mattermost
+## Docker Images
+DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.45.2@sha256:e84b639c061c8888be91939c78dae9b1525359954e405ab0d9868a46861bd21b"
+DOCKER_IMAGE_DOCKERLINT += "hadolint/hadolint:v2.9.2@sha256:d355bd7df747a0f124f3b5e7b21e9dafd0cb19732a276f901f0fdee243ec1f3b"
+
+## Go Variables
+# Go executable
+GO                           := $(shell which go)
+# LDFLAGS
+GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildHash=$(APP_COMMIT)"
+GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildVersion=$(APP_VERSION)"
+GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildDate=$(BUILD_DATE)"
+# Architectures to build for
+GO_BUILD_PLATFORMS           = linux-amd64 linux-arm64 darwin-amd64 darwin-arm64
+GO_BUILD_PLATFORMS_ARTIFACTS = $(foreach cmd,$(addprefix go-build/,${APP_NAME}),$(addprefix $(cmd)-,$(GO_BUILD_PLATFORMS)))
+# Build options
+GO_BUILD_OPTS                += -mod=readonly -trimpath
+GO_TEST_OPTS                 += -mod=readonly -failfast -race
+# Temporary folder to output compiled binaries artifacts
+GO_OUT_BIN_DIR               := ./dist
+
+## General Variables
+# Use repository name as application name
+APP_NAME    := $(shell basename -s .git `git config --get remote.origin.url`)
+# Get current commit
+APP_COMMIT  := $(shell git log --pretty=format:'%h' -n 1)
+# Check if we are in a release tag, if yes use it as app version.
+APP_VERSION := $(shell git describe --abbrev=0 --exact-match --tags > /dev/null 2>&1 || echo dev-$(APP_COMMIT))
+# Get current date and format like: 2022-04-27 11:32
+BUILD_DATE  := $(shell date +%Y-%m-%d\ %H:%M)
+
+## General Configuration Variables
+# We don't need make's built-in rules.
+MAKEFLAGS     += --no-builtin-rules
+# Be pedantic about undefined variables.
+MAKEFLAGS     += --warn-undefined-variables
+# Set help as default target
+.DEFAULT_GOAL := help
+
+# ====================================================================================
+# Colors
+
+BLUE   := $(shell printf "\033[34m")
+YELLOW := $(shell printf "\033[33m")
+RED    := $(shell printf "\033[31m")
+GREEN  := $(shell printf "\033[32m")
+CYAN   := $(shell printf "\033[36m")
+CNone  := $(shell printf "\033[0m")
+
+# ====================================================================================
+# Logger
+
+TIME_LONG	= `date +%Y-%m-%d' '%H:%M:%S`
+TIME_SHORT	= `date +%H:%M:%S`
+TIME		= $(TIME_SHORT)
+
+INFO = echo ${TIME} ${BLUE}[ .. ]${CNone}
+WARN = echo ${TIME} ${YELLOW}[WARN]${CNone}
+ERR  = echo ${TIME} ${RED}[FAIL]${CNone}
+OK   = echo ${TIME} ${GREEN}[ OK ]${CNone}
+FAIL = (echo ${TIME} ${RED}[FAIL]${CNone} && false)
+
+# ====================================================================================
+# Targets
+
+help: ## to get help
+	@echo "Usage:"
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) |\
+	awk 'BEGIN {FS = ":.*?## "}; {printf "make ${CYAN}%-30s${CNone} %s\n", $$1, $$2}'
+
+.PHONY: lint
+lint: go-lint go-mod-check docker-lint ## to lint all
 
 .PHONY: test
-test:
-	go test -v -mod=readonly -failfast -race ./...
-
-.PHONY: build
-build:
-	mkdir -p dist
-	env GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -o dist/rtcd -ldflags '$(LDFLAGS)' -mod=readonly -trimpath ./cmd/rtcd
+test: go-test ## to test all
 
 .PHONY: docker-build
-docker-build:
-	@if ! [ -x "$$(command -v docker)" ]; then \
-		echo "Docker is not installed. Please see https://docs.docker.com/get-docker for installation instructions."; \
-		exit 127; \
-	fi; \
+docker-build: go-build ## to build the docker image
+	@$(INFO) Performing Docker build...
+	$(DOCKER) build -f ${DOCKER_FILE} . \
+	-t ${APP_NAME}:${APP_VERSION} || ${FAIL}
+	@$(OK) Performing Docker build ${APP_NAME}:${APP_VERSION}
 
-	@[ "${tag}" ] || ( echo "docker-build requires a tag. Set a tag with: \"make docker-build tag=rtcd:my_tag\""; exit 128 )
+.PHONY: docker-push
+docker-push: ## to push the docker image
+	@$(INFO) Pushing to registry...
+	$(DOCKER) tag ${APP_NAME}:${APP_VERSION} $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION} || ${FAIL}
+	$(DOCKER) push $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION} || ${FAIL}
+	@$(OK) Pushing to registry $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION}
 
-	docker build -f build/Dockerfile . -t $(tag)
+.PHONY: docker-sbom
+docker-sbom: ## to print a sbom report
+	@$(INFO) Performing Docker sbom report...
+	$(DOCKER) sbom ${APP_NAME}:${APP_VERSION} || ${FAIL}
+	@$(OK) Performing Docker sbom report
 
-.PHONY: doc
-doc:
-	go run ./scripts/env_config.go ./docs/env_config.md
+.PHONY: docker-scan
+docker-scan: ## to print a vulnerability report
+	@$(INFO) Performing Docker scan report...
+	$(DOCKER) scan ${APP_NAME}:${APP_VERSION} || ${FAIL}
+	@$(OK) Performing Docker scan report
+
+.PHONY: docker-lint
+docker-lint: ## to lint the Dockerfile
+	@$(INFO) Dockerfile linting...
+	$(DOCKER) run ${DOCKER_OPTS} \
+	${DOCKER_IMAGE_DOCKERLINT} \
+	< ${DOCKER_FILE}
+	@$(OK) Dockerfile linting
+
+go-build: $(GO_BUILD_PLATFORMS_ARTIFACTS) ## to build binaries
+
+.PHONY: go-build
+go-build/%:
+	@$(INFO) go build $*...
+	target="$*"; \
+	command="$${target%%-*}"; \
+	platform_ext="$${target#*-}"; \
+	platform="$${platform_ext%.*}"; \
+	export GOOS="$${platform%%-*}"; \
+	export GOARCH="$${platform#*-}"; \
+	echo export GOOS=$${GOOS}; \
+	echo export GOARCH=$${GOARCH}; \
+	CGO_ENABLED=0 \
+	$(GO) build ${GO_BUILD_OPTS} \
+	-ldflags '${GO_LDFLAGS}' \
+	-o ${GO_OUT_BIN_DIR}/$* \
+	${CONFIG_APP_CODE} || ${FAIL}
+	@$(OK) go build $*
+
+.PHONY: go-run
+go-run: ## to run locally for development
+	@$(INFO) running locally...
+	$(GO) run ${GO_BUILD_OPTS} ${CONFIG_APP_CODE} || ${FAIL}
+	@$(OK) running locally
+
+.PHONY: go-test
+go-test: ## to run tests
+	@$(INFO) testing...
+	$(GO) test ${GO_TEST_OPTS} ./... || ${FAIL}
+	@$(OK) testing
+
+.PHONY: go-mod-check
+go-mod-check: ## to check go mod files consistency
+	@$(INFO) Checking go mod files consistency...
+	go mod tidy
+	git --no-pager diff --exit-code go.mod go.sum || \
+	(${WARN} Please run "go mod tidy" and commit the changes in go.mod and go.sum. && ${FAIL} ; exit 128 )
+	@$(OK) Checking go mod files consistency
+
+.PHONY: go-update-dependencies
+go-update-dependencies: ## to update go dependencies (vendor)
+	@$(INFO) updating go dependencies...
+	$(GO) get -u ./... && \
+	$(GO) mod vendor && \
+	$(GO) mod tidy || ${FAIL}
+	@$(OK) updating go dependencies
+
+.PHONY: go-lint
+go-lint: ## to lint go code
+	@$(INFO) App linting...
+	GOCACHE="/tmp" docker run ${DOCKER_OPTS} \
+	-v $(PWD):/app -w /app \
+	-e GOCACHE="/tmp" \
+	-e GOLANGCI_LINT_CACHE="/tmp" \
+	${DOCKER_IMAGE_GOLINT} \
+	golangci-lint run ./... || ${FAIL}
+	@$(OK) App linting
+
+.PHONY: go-doc
+go-doc: ## to generate documentation
+	@$(INFO) Generating Documentation...
+	$(GO) run ./scripts/env_config.go ./docs/env_config.md || ${FAIL}
+	@$(OK) Generating Documentation
 
 .PHONY: clean
-clean:
-	rm -rf dist
+clean: ## to clean-up
+	@$(INFO) cleaning /${GO_OUT_BIN_DIR} folder...
+	rm -rf ${GO_OUT_BIN_DIR} || ${FAIL}
+	@$(OK) cleaning /${GO_OUT_BIN_DIR} folder

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.bu
 GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildVersion=$(APP_VERSION)"
 GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildDate=$(BUILD_DATE)"
 # Architectures to build for
-GO_BUILD_PLATFORMS           = linux-amd64 linux-arm64 darwin-amd64 darwin-arm64
+GO_BUILD_PLATFORMS           ?= linux-amd64 linux-arm64 darwin-amd64 darwin-arm64
 GO_BUILD_PLATFORMS_ARTIFACTS = $(foreach cmd,$(addprefix go-build/,${APP_NAME}),$(addprefix $(cmd)-,$(GO_BUILD_PLATFORMS)))
 # Build options
 GO_BUILD_OPTS                += -mod=readonly -trimpath

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -6,7 +6,10 @@ FROM golang:1.17.9-alpine@sha256:5c2fcfeb58ad9d4948d94e7b2d0432a9bc38bee0f8dfb41
 # Setup directories structure and compile
 COPY . /src
 WORKDIR /src
-RUN apk add make=4.3-r0 --no-cache \
+RUN apk add \
+    make=4.3-r0 \
+    git=2.34.2-r0 \
+    --no-cache \
     && make build
 
 # Shrink final image since we only need the rtcd binary

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,24 +1,22 @@
 # This dockerfile is used to build Mattermost rtcd
 # A multi stage build, with golang:1.17.9-alpine used as a builder
-# and gcr.io/distroless/static as runner 
+# and gcr.io/distroless/static as runner
 FROM golang:1.17.9-alpine@sha256:5c2fcfeb58ad9d4948d94e7b2d0432a9bc38bee0f8dfb41d383f38a18b75c38d as builder
-RUN apk update && apk add make
 
-# Setup Golang directories structure and compile
-RUN mkdir -p /rtcd
-ADD . /rtcd
-WORKDIR /rtcd
-RUN make build
+# Setup directories structure and compile
+COPY . /src
+WORKDIR /src
+RUN apk add make=4.3-r0 --no-cache \
+    && make build
 
 # Shrink final image since we only need the rtcd binary
 # and use distroless container image as runner for security
 FROM gcr.io/distroless/static@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f as runner
-COPY --from=builder /rtcd/dist/rtcd /rtcd/rtcd
+COPY --from=builder /src/dist/rtcd-linux-amd64 /opt/rtcd/bin/rtcd
 
 # We should refrain from running as privileged user
 # Run as UID for nobody
 USER 65534
 
-WORKDIR /rtcd
+WORKDIR /opt/rtcd/bin
 ENTRYPOINT ["./rtcd"]
-


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This is a first proposal, on Makefile refactoring introducing the following improvements:

- Decoupling of Makefile Variables from actual targets
- Easy to develop locally, not requiring binaries on the actual dev machine (docker)
- Better makefile logging
- Dockerfile linting
- Auto generated Makefile help command
- Security improvements with the introduction of SBOM and Vulnerabilities reporting. Moreover `docker run` runs as a non privileged user
- Documentation with inline commenting
- Aims to be easily portable to other Mattermost Repositories

```bash
❯ make                                                                          
Usage:
make help                           to get help
make lint                           to lint all
make test                           to test all
make docker-build                   to build the docker image
make docker-push                    to push the docker image
make docker-sbom                    to print a sbom report
make docker-scan                    to print a vulnerability report
make docker-lint                    to lint the Dockerfile
make go-build                       to build binaries
make go-run                         to run locally for development
make go-test                        to run tests
make go-mod-check                   to check go mod files consistency
make go-update-dependencies         to update go dependencies (vendor)
make go-lint                        to lint go code
make go-doc                         to generate documentation
make clean                          to clean-up
```
Finally We also perform relevant changes to the `Dockerfile`

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/DOPS-942
