### PR TITLE
Performance improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/stretchr/testify v1.7.1
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/crypto v0.0.0-20220314234724-5d542ad81a58
+	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e
 )
 
 require (
@@ -55,7 +56,6 @@ require (
 	github.com/wiggin77/srslog v1.0.1 // indirect
 	golang.org/x/exp v0.0.0-20200908183739-ae8ad444f925 // indirect
 	golang.org/x/net v0.0.0-20220225172249-27dd8689420f // indirect
-	golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	google.golang.org/protobuf v1.27.1 // indirect
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0 // indirect

--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -23,7 +23,7 @@ func (c *call) getSession(sessionID string) *session {
 	return c.sessions[sessionID]
 }
 
-func (c *call) addSession(cfg SessionConfig, rtcConn *webrtc.PeerConnection) (*session, bool) {
+func (c *call) addSession(cfg SessionConfig, rtcConn *webrtc.PeerConnection, closeCb func() error) (*session, bool) {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 	if s := c.sessions[cfg.SessionID]; s != nil {
@@ -36,6 +36,7 @@ func (c *call) addSession(cfg SessionConfig, rtcConn *webrtc.PeerConnection) (*s
 		iceInCh:       make(chan []byte, signalChSize*2),
 		sdpInCh:       make(chan []byte, signalChSize),
 		closeCh:       make(chan struct{}),
+		closeCb:       closeCb,
 		tracksCh:      make(chan *webrtc.TrackLocalStaticRTP, tracksChSize),
 		trackEnableCh: make(chan bool, tracksChSize),
 		rtpSendersMap: make(map[*webrtc.TrackLocalStaticRTP]*webrtc.RTPSender),

--- a/service/rtc/multi_conn.go
+++ b/service/rtc/multi_conn.go
@@ -1,0 +1,131 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package rtc
+
+import (
+	"errors"
+	"net"
+	"os"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	receiveMTU = 8192
+)
+
+type multiConn struct {
+	conns        []net.PacketConn
+	addr         net.Addr
+	readResultCh chan readResult
+	closeCh      chan struct{}
+	bufPool      *sync.Pool
+	counter      uint64
+	wg           sync.WaitGroup
+}
+
+type readResult struct {
+	n    int
+	addr net.Addr
+	err  error
+	buf  []byte
+}
+
+func newMultiConn(conns []net.PacketConn) (*multiConn, error) {
+	if len(conns) == 0 {
+		return nil, errors.New("conns should not be empty")
+	}
+	for _, conn := range conns {
+		if conn == nil {
+			return nil, errors.New("invalid nil conn")
+		}
+	}
+	var mc multiConn
+	mc.conns = conns
+	mc.addr = conns[0].LocalAddr()
+	mc.readResultCh = make(chan readResult)
+	mc.closeCh = make(chan struct{})
+	mc.bufPool = &sync.Pool{
+		New: func() interface{} {
+			return make([]byte, receiveMTU)
+		},
+	}
+	mc.wg.Add(len(conns))
+	for _, conn := range conns {
+		go mc.reader(conn)
+	}
+	return &mc, nil
+}
+
+func (mc *multiConn) reader(conn net.PacketConn) {
+	defer mc.wg.Done()
+	var res readResult
+	for {
+		res.buf = mc.bufPool.Get().([]byte)
+		res.n, res.addr, res.err = conn.ReadFrom(res.buf)
+		select {
+		case mc.readResultCh <- res:
+		case <-mc.closeCh:
+			return
+		}
+		if os.IsTimeout(res.err) {
+			continue
+		} else if res.err != nil {
+			break
+		}
+	}
+}
+
+func (mc *multiConn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
+	res := <-mc.readResultCh
+	copy(p, res.buf[:res.n])
+	mc.bufPool.Put(res.buf)
+	return res.n, res.addr, res.err
+}
+
+func (mc *multiConn) WriteTo(p []byte, addr net.Addr) (n int, err error) {
+	// Simple round-robin to equally distribute the writes among the connections.
+	idx := (atomic.AddUint64(&mc.counter, 1) - 1) % uint64(len(mc.conns))
+	return mc.conns[idx].WriteTo(p, addr)
+}
+
+func (mc *multiConn) Close() error {
+	var err error
+	close(mc.closeCh)
+	for _, conn := range mc.conns {
+		err = conn.Close()
+	}
+	mc.wg.Wait()
+	close(mc.readResultCh)
+	return err
+}
+
+func (mc *multiConn) LocalAddr() net.Addr {
+	return mc.addr
+}
+
+func (mc *multiConn) SetDeadline(t time.Time) error {
+	var err error
+	for _, conn := range mc.conns {
+		err = conn.SetDeadline(t)
+	}
+	return err
+}
+
+func (mc *multiConn) SetReadDeadline(t time.Time) error {
+	var err error
+	for _, conn := range mc.conns {
+		err = conn.SetReadDeadline(t)
+	}
+	return err
+}
+
+func (mc *multiConn) SetWriteDeadline(t time.Time) error {
+	var err error
+	for _, conn := range mc.conns {
+		err = conn.SetWriteDeadline(t)
+	}
+	return err
+}

--- a/service/rtc/multi_conn_test.go
+++ b/service/rtc/multi_conn_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package rtc
+
+import (
+	"context"
+	"net"
+	// "sync"
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMultiConn(t *testing.T) {
+	t.Run("error - nil conns", func(t *testing.T) {
+		mc, err := newMultiConn(nil)
+		require.Error(t, err)
+		require.Equal(t, "conns should not be empty", err.Error())
+		require.Nil(t, mc)
+
+	})
+
+	t.Run("error - empty conns", func(t *testing.T) {
+		mc, err := newMultiConn([]net.PacketConn{})
+		require.Error(t, err)
+		require.Equal(t, "conns should not be empty", err.Error())
+		require.Nil(t, mc)
+	})
+
+	t.Run("error - nil conn", func(t *testing.T) {
+		mc, err := newMultiConn([]net.PacketConn{nil})
+		require.Error(t, err)
+		require.Equal(t, "invalid nil conn", err.Error())
+		require.Nil(t, mc)
+	})
+
+	t.Run("success", func(t *testing.T) {
+		var listenConfig net.ListenConfig
+		conn1, err := listenConfig.ListenPacket(context.Background(), "udp4", ":0")
+		require.NoError(t, err)
+		require.NotNil(t, conn1)
+		mc, err := newMultiConn([]net.PacketConn{conn1})
+		require.NoError(t, err)
+		require.NotNil(t, mc)
+		err = mc.Close()
+		require.NoError(t, err)
+		err = conn1.Close()
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "use of closed network connection")
+	})
+}
+
+func TestMultiConnReadWrite(t *testing.T) {
+	listenConfig := net.ListenConfig{
+		Control: func(network, address string, c syscall.RawConn) error {
+			return c.Control(func(fd uintptr) {
+				err := unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEADDR, 1)
+				require.NoError(t, err)
+				err = unix.SetsockoptInt(int(fd), unix.SOL_SOCKET, unix.SO_REUSEPORT, 1)
+				require.NoError(t, err)
+			})
+		},
+	}
+
+	conn1, err := listenConfig.ListenPacket(context.Background(), "udp4", ":0")
+	require.NoError(t, err)
+	require.NotNil(t, conn1)
+	conn2, err := listenConfig.ListenPacket(context.Background(), "udp4", conn1.LocalAddr().String())
+	require.NoError(t, err)
+	require.NotNil(t, conn2)
+	require.Equal(t, conn1.LocalAddr(), conn2.LocalAddr())
+
+	mc, err := newMultiConn([]net.PacketConn{conn1, conn2})
+	require.NoError(t, err)
+	require.NotNil(t, mc)
+	defer mc.Close()
+
+	conn1Data := []byte("conn1 data")
+	_, err = conn1.WriteTo(conn1Data, mc.LocalAddr())
+	require.NoError(t, err)
+	receivedData := make([]byte, receiveMTU)
+	read, _, err := mc.ReadFrom(receivedData)
+	require.NoError(t, err)
+	require.Equal(t, conn1Data, receivedData[:read])
+
+	conn2Data := []byte("conn2 data")
+	_, err = conn1.WriteTo(conn2Data, mc.LocalAddr())
+	require.NoError(t, err)
+	read, _, err = mc.ReadFrom(receivedData)
+	require.NoError(t, err)
+	require.Equal(t, conn2Data, receivedData[:read])
+
+	require.Equal(t, uint64(0), mc.counter)
+	_, err = mc.WriteTo(conn1Data, conn1.LocalAddr())
+	require.NoError(t, err)
+	require.Equal(t, uint64(1), mc.counter)
+	_, err = mc.WriteTo(conn2Data, conn2.LocalAddr())
+	require.NoError(t, err)
+	require.Equal(t, uint64(2), mc.counter)
+}

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -41,11 +41,12 @@ type session struct {
 	sdpInCh              chan []byte
 
 	closeCh chan struct{}
+	closeCb func() error
 
 	mut sync.RWMutex
 }
 
-func (s *Server) addSession(cfg SessionConfig, peerConn *webrtc.PeerConnection) (*session, error) {
+func (s *Server) addSession(cfg SessionConfig, peerConn *webrtc.PeerConnection, closeCb func() error) (*session, error) {
 	if err := cfg.IsValid(); err != nil {
 		return nil, err
 	}
@@ -78,7 +79,7 @@ func (s *Server) addSession(cfg SessionConfig, peerConn *webrtc.PeerConnection) 
 	}
 	g.mut.Unlock()
 
-	us, ok := c.addSession(cfg, peerConn)
+	us, ok := c.addSession(cfg, peerConn, closeCb)
 	if !ok {
 		return nil, fmt.Errorf("user session already exists")
 	}

--- a/service/rtc/session_test.go
+++ b/service/rtc/session_test.go
@@ -4,6 +4,8 @@
 package rtc
 
 import (
+	"errors"
+	"sync"
 	"testing"
 
 	"github.com/pion/webrtc/v3"
@@ -15,7 +17,7 @@ func TestAddSession(t *testing.T) {
 	defer shutdown()
 
 	t.Run("invalid config", func(t *testing.T) {
-		us, err := server.addSession(SessionConfig{}, nil)
+		us, err := server.addSession(SessionConfig{}, nil, nil)
 		require.Error(t, err)
 		require.Nil(t, us)
 	})
@@ -27,7 +29,7 @@ func TestAddSession(t *testing.T) {
 			UserID:    "test",
 			SessionID: "test",
 		}
-		us, err := server.addSession(cfg, nil)
+		us, err := server.addSession(cfg, nil, nil)
 		require.Error(t, err)
 		require.Equal(t, "peerConn should not be nil", err.Error())
 		require.Nil(t, us)
@@ -44,11 +46,81 @@ func TestAddSession(t *testing.T) {
 		peerConn, err := webrtc.NewPeerConnection(webrtc.Configuration{})
 		require.NoError(t, err)
 
-		us, err := server.addSession(cfg, peerConn)
+		us, err := server.addSession(cfg, peerConn, nil)
 		require.NoError(t, err)
 		require.NotNil(t, us)
 
 		err = server.CloseSession(cfg.SessionID)
 		require.NoError(t, err)
 	})
+
+	t.Run("closeCb", func(t *testing.T) {
+		cfg := SessionConfig{
+			GroupID:   "test",
+			CallID:    "test",
+			UserID:    "test",
+			SessionID: "test",
+		}
+
+		peerConn, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+		require.NoError(t, err)
+
+		cbError := errors.New("closeCb failed")
+		closeCbError := func() error {
+			return cbError
+		}
+
+		var cbCalled bool
+		closeCbSuccess := func() error {
+			cbCalled = true
+			return nil
+		}
+
+		us, err := server.addSession(cfg, peerConn, closeCbError)
+		require.NoError(t, err)
+		require.NotNil(t, us)
+
+		err = server.CloseSession(cfg.SessionID)
+		require.Error(t, err)
+		require.Equal(t, cbError, err)
+
+		us, err = server.addSession(cfg, peerConn, closeCbSuccess)
+		require.NoError(t, err)
+		require.NotNil(t, us)
+
+		err = server.CloseSession(cfg.SessionID)
+		require.NoError(t, err)
+		require.True(t, cbCalled)
+	})
+}
+
+func TestCloseSessionConcurrent(t *testing.T) {
+	server, shutdown := setupServer(t)
+	defer shutdown()
+
+	cfg := SessionConfig{
+		GroupID:   "test",
+		CallID:    "test",
+		UserID:    "test",
+		SessionID: "test",
+	}
+
+	peerConn, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	require.NoError(t, err)
+
+	us, err := server.addSession(cfg, peerConn, nil)
+	require.NoError(t, err)
+	require.NotNil(t, us)
+
+	var wg sync.WaitGroup
+	n := 20
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			err := server.CloseSession(cfg.SessionID)
+			require.Nil(t, err)
+		}()
+	}
+	wg.Wait()
 }


### PR DESCRIPTION
#### Summary

PR addresses two issues discovered during initial performance testing.

1. We add a callback to be run on connection close and also attempt to close the connection on the rtc side as well when failure occurs. This prevents possible resource leaks due to missing events on the websocket channel with the plugin (e.g. mattermost restarts as a user disconnects).
2. We listen to the same addr/port multiple times (once per CPU available) to allow for better receive throughput. This optimization has showed the best improvements during testing. 

Implementation wise I originally hacked the [`pion.ice`](https://pkg.go.dev/github.com/pion/ice/v2) code as it made it for a much  simpler solution which also provided higher read/write concurrency. Unfortunately that required breaking changes plus a need to port everything upstream so went with a less optimal approach by implementing a `multiConn` object to do everything on our side. So we are still passing a single `net.PacketConn` but in reality this is wrapping multiple connections. Limitations with the current approach:

- Writes are still happening from a single goroutine.
- While reads are concurrent there's still a bottleneck of a single caller as all results need to go through the same channel.
- We have to copy data buffers.

That said, I load-tested both approaches and overall there wasn't any noticeable difference but I'd fully expect the latter to struggle sooner when reaching the instance limits.

Fortunately [`ice.UDPMux`](https://pkg.go.dev/github.com/pion/ice/v2#UDPMux) is an interface so we still have the option to provide our own implementation which may be the best solution from a performance perspective although it will require more implementation effort.