### PR TITLE
Fix env vars document generation

### DIFF
--- a/docs/env_config.md
+++ b/docs/env_config.md
@@ -21,5 +21,3 @@ RTCD_LOGGER_FILELEVEL                      String
 RTCD_LOGGER_FILELOCATION                   String
 RTCD_LOGGER_ENABLECOLOR                    True or False
 ```
-                    True or False
-```

--- a/scripts/env_config.go
+++ b/scripts/env_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
 package main
 
 import (
@@ -20,6 +23,12 @@ func main() {
 		log.Fatalf("failed to write file: %s", err.Error())
 	}
 	defer outFile.Close()
+	if err := outFile.Truncate(0); err != nil {
+		log.Fatalf("failed to truncate file: %s", err.Error())
+	}
+	if _, err := outFile.Seek(0, 0); err != nil {
+		log.Fatalf("failed to seek file: %s", err.Error())
+	}
 	fmt := "### Config Environment Overrides\n\n```\nKEY	TYPE\n{{range .}}{{usage_key .}}	{{usage_type .}}\n{{end}}```\n"
 	tabs := tabwriter.NewWriter(outFile, 1, 0, 4, ' ', 0)
 	_ = envconfig.Usagef("rtcd", &service.Config{}, tabs, fmt)


### PR DESCRIPTION
#### Summary

We empty the file prior to writing or it gets overwritten potentially causing some issues.

