### PR TITLE
Fix conflict with Calls plugin metrics

### DIFF
--- a/service/perf/metrics.go
+++ b/service/perf/metrics.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	metricsSubSystemRTC = "rtc"
-	metricsSubSystemWS  = "websocket"
+	metricsSubSystemWS  = "ws"
 )
 
 type Metrics struct {


### PR DESCRIPTION
#### Summary

Fixing a conflict with plugin export metrics that prevented the plugin from starting up properly.
