### PR TITLE
[MM-43330] Log audit info on http requests

### DIFF
--- a/service/audit.go
+++ b/service/audit.go
@@ -1,0 +1,54 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/mattermost/mattermost-server/v6/shared/mlog"
+)
+
+type httpData struct {
+	err     string
+	code    int
+	reqData map[string]string
+	resData map[string]string
+}
+
+func (s *Service) httpAudit(handler string, data *httpData, w http.ResponseWriter, r *http.Request) {
+	fields := append(reqAuditFields(r), mlog.Int("code", data.code))
+	status := "fail"
+	if data.err == "" {
+		status = "success"
+	} else {
+		data.resData["error"] = data.err
+		fields = append(fields, mlog.Err(fmt.Errorf("%s", data.err)))
+	}
+	if clientID := data.reqData["clientID"]; clientID != "" {
+		fields = append(fields, mlog.String("clientID", clientID))
+	}
+	s.log.Debug(handler, append(fields, mlog.String("status", status))...)
+	if w != nil {
+		data.resData["code"] = fmt.Sprintf("%d", data.code)
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(data.code)
+		if err := json.NewEncoder(w).Encode(data.resData); err != nil {
+			s.log.Error("failed to encode data", mlog.Err(err))
+		}
+	}
+}
+
+func reqAuditFields(req *http.Request) []mlog.Field {
+	delete(req.Header, "Authorization")
+	fields := []mlog.Field{
+		mlog.String("remoteAddr", req.RemoteAddr),
+		mlog.String("method", req.Method),
+		mlog.String("url", req.URL.String()),
+		mlog.Any("header", req.Header),
+		mlog.String("host", req.Host),
+	}
+	return fields
+}

--- a/service/ws/client_test.go
+++ b/service/ws/client_test.go
@@ -59,14 +59,14 @@ func TestNewClientWithAuth(t *testing.T) {
 	authToken := random.NewID()
 	clientID := random.NewID()
 
-	authCb := func(w http.ResponseWriter, r *http.Request) (string, error) {
+	authCb := func(w http.ResponseWriter, r *http.Request) (string, int, error) {
 		authHeader := r.Header.Get("Authorization")
 		require.NotEmpty(t, authHeader)
 		if fields := strings.Fields(authHeader); len(fields) > 1 && fields[1] == authToken {
-			return clientID, nil
+			return clientID, 200, nil
 		}
 
-		return "", fmt.Errorf("auth check failed")
+		return "", 401, fmt.Errorf("auth check failed")
 	}
 
 	server, addr, shutdown := setupServer(t, WithAuthCb(authCb))

--- a/service/ws/server.go
+++ b/service/ws/server.go
@@ -21,7 +21,7 @@ const (
 	writeWaitTime = 10 * time.Second
 )
 
-type AuthCb func(w http.ResponseWriter, r *http.Request) (string, error)
+type AuthCb func(w http.ResponseWriter, r *http.Request) (string, int, error)
 
 type Server struct {
 	cfg       ServerConfig
@@ -111,7 +111,7 @@ func (s *Server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var err error
 	var clientID string
 	if s.authCb != nil {
-		clientID, err = s.authCb(w, r)
+		clientID, _, err = s.authCb(w, r)
 		if err != nil {
 			s.log.Error("authCb failed", mlog.Err(err))
 			return

--- a/service/ws/server_test.go
+++ b/service/ws/server_test.go
@@ -116,9 +116,9 @@ func TestNewServer(t *testing.T) {
 func TestServeHTTP(t *testing.T) {
 	upgradeRan := false
 
-	authCb := func(w http.ResponseWriter, r *http.Request) (string, error) {
+	authCb := func(w http.ResponseWriter, r *http.Request) (string, int, error) {
 		upgradeRan = true
-		return "", nil
+		return "", 0, nil
 	}
 
 	_, addr, shutdown := setupServer(t, WithAuthCb(authCb))
@@ -308,8 +308,8 @@ func TestWithAuthCb(t *testing.T) {
 	defer shutdown()
 	require.Nil(t, s.authCb)
 
-	authCb := func(w http.ResponseWriter, r *http.Request) (string, error) {
-		return "", nil
+	authCb := func(w http.ResponseWriter, r *http.Request) (string, int, error) {
+		return "", 0, nil
 	}
 
 	s2, _, shutdown2 := setupServer(t, WithAuthCb(authCb))


### PR DESCRIPTION
#### Summary

PR adds some additional logs to HTTP requests requiring authorization. 
Currently logging more or less everything the request gives us. Happy to make any needed change/addition.

Example log:

```
debug [2022-04-29 16:30:40.860 +02:00] registerClient caller="service/audit.go:33" remoteAddr="192.168.1.108:42846" method=POST url=/register header=map[Accept:[*/*] Content-Length:[31] Content-Type:[application/x-www-form-urlencoded] User-Agent:[curl/7.68.0]] host="172.17.0.1:8045" code=400 error="registration failed: already registered" clientID=localPluginAAAA status=fail
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-43330
