### PR TITLE
Avoid failure if setting UDP buffer sizes errors

### DIFF
--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -109,12 +109,13 @@ func (s *Server) Start() error {
 		s.log.Info(fmt.Sprintf("rtc: server is listening on udp %d", s.cfg.ICEPortUDP))
 
 		if err := udpConn.(*net.UDPConn).SetWriteBuffer(udpSocketBufferSize); err != nil {
-			return fmt.Errorf("failed to set udp send buffer: %w", err)
+			s.log.Warn("rtc: failed to set udp send buffer", mlog.Err(err))
 		}
 
 		if err := udpConn.(*net.UDPConn).SetReadBuffer(udpSocketBufferSize); err != nil {
-			return fmt.Errorf("failed to set udp receive buffer: %w", err)
+			s.log.Warn("rtc: failed to set udp receive buffer", mlog.Err(err))
 		}
+
 		connFile, err := udpConn.(*net.UDPConn).File()
 		if err != nil {
 			return fmt.Errorf("failed to get udp conn file: %w", err)


### PR DESCRIPTION
#### Summary

I was looking into adding a runtime platform check but it will make the initialization code unnecessarily more complex so opting for logging a warning instead of failing. 

@cpoile Let me know if this is enough to get it working on your end otherwise I'll go with a different approach.
