### PR TITLE
[MM-44062] Use STUN to find public IP

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -10,6 +10,7 @@ security.admin_secret_key = ""
 [rtc]
 ice_port_udp = 8443
 ice_host_override = ""
+ice_servers = []
 
 [store]
 data_source = "/tmp/rtcd_db"

--- a/docs/env_config.md
+++ b/docs/env_config.md
@@ -11,6 +11,7 @@ RTCD_API_SECURITY_ADMINSECRETKEY           String
 RTCD_API_SECURITY_ALLOWSELFREGISTRATION    True or False
 RTCD_RTC_ICEPORTUDP                        Integer
 RTCD_RTC_ICEHOSTOVERRIDE                   String
+RTCD_RTC_ICESERVERS                        Comma-separated list of String
 RTCD_STORE_DATASOURCE                      String
 RTCD_LOGGER_ENABLECONSOLE                  True or False
 RTCD_LOGGER_CONSOLEJSON                    True or False

--- a/service/rtc/config.go
+++ b/service/rtc/config.go
@@ -13,6 +13,8 @@ type ServerConfig struct {
 	// ICEHostOverride optionally specifies an IP address (or hostname)
 	// to be used as the main host ICE candidate.
 	ICEHostOverride string `toml:"ice_host_override"`
+	// A comma separated list of ICE servers URLs (STUN/TURN) to use.
+	ICEServers []string `toml:"ice_servers"`
 }
 
 func (c ServerConfig) IsValid() error {

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -82,6 +82,15 @@ func (s *Server) ReceiveCh() <-chan Message {
 }
 
 func (s *Server) Start() error {
+	if s.cfg.ICEHostOverride == "" && len(s.cfg.ICEServers) > 0 {
+		addr, err := getPublicIP(s.cfg.ICEPortUDP, s.cfg.ICEServers)
+		if err != nil {
+			return fmt.Errorf("failed to get public IP address: %w", err)
+		}
+		s.cfg.ICEHostOverride = addr
+		s.log.Info("got public IP address", mlog.String("addr", addr))
+	}
+
 	var conns []net.PacketConn
 	for i := 0; i < runtime.NumCPU(); i++ {
 		listenConfig := net.ListenConfig{

--- a/service/rtc/stun.go
+++ b/service/rtc/stun.go
@@ -1,0 +1,96 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package rtc
+
+import (
+	"fmt"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/pion/stun"
+)
+
+func getPublicIP(port int, iceServers []string) (string, error) {
+	conn, err := net.ListenUDP("udp4", &net.UDPAddr{
+		Port: port,
+	})
+	if err != nil {
+		return "", err
+	}
+	defer conn.Close()
+
+	var stunURL string
+	for _, u := range iceServers {
+		if strings.HasPrefix(u, "stun:") {
+			stunURL = u
+		}
+	}
+	if stunURL == "" {
+		return "", fmt.Errorf("no STUN server URL was found")
+	}
+	serverURL := stunURL[strings.Index(stunURL, ":")+1:]
+	serverAddr, err := net.ResolveUDPAddr("udp", serverURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve stun host: %w", err)
+	}
+
+	xoraddr, err := getXORMappedAddr(conn, serverAddr, 5*time.Second)
+	if err != nil {
+		return "", fmt.Errorf("failed to get public address: %w", err)
+	}
+
+	return xoraddr.IP.String(), nil
+}
+
+func getXORMappedAddr(conn net.PacketConn, serverAddr net.Addr, deadline time.Duration) (*stun.XORMappedAddress, error) {
+	if deadline > 0 {
+		if err := conn.SetReadDeadline(time.Now().Add(deadline)); err != nil {
+			return nil, err
+		}
+	}
+	defer func() {
+		if deadline > 0 {
+			_ = conn.SetReadDeadline(time.Time{})
+		}
+	}()
+	resp, err := stunRequest(
+		func(p []byte) (int, error) {
+			n, _, errr := conn.ReadFrom(p)
+			return n, errr
+		},
+		func(b []byte) (int, error) {
+			return conn.WriteTo(b, serverAddr)
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+	var addr stun.XORMappedAddress
+	if err = addr.GetFrom(resp); err != nil {
+		return nil, err
+	}
+	return &addr, nil
+}
+
+func stunRequest(read func([]byte) (int, error), write func([]byte) (int, error)) (*stun.Message, error) {
+	req, err := stun.Build(stun.BindingRequest, stun.TransactionID)
+	if err != nil {
+		return nil, err
+	}
+	if _, err = write(req.Raw); err != nil {
+		return nil, err
+	}
+	const maxMessageSize = 1280
+	bs := make([]byte, maxMessageSize)
+	n, err := read(bs)
+	if err != nil {
+		return nil, err
+	}
+	res := &stun.Message{Raw: bs[:n]}
+	if err := res.Decode(); err != nil {
+		return nil, err
+	}
+	return res, nil
+}


### PR DESCRIPTION
#### Summary

We are moving to this side the STUN logic to figure out an instance's own public IP address which will trigger only in case the `ICEHostOverride` is empty and ICE servers are provided.

This is especially helpful for Cloud operations now that we have simplified the networking design, with pods having public IP addresses.

Big thanks to @angeloskyratzakos for quickly validating that this approach can work.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44062