### PR TITLE
Change registration flow to require client provided auth key

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -8,10 +8,9 @@ The authentication flow is as follows:
 
 #### Registration
 
-1. Client makes a request for registration by providing a random string which uniquely identifies the client.
-2. Server generates a 32 characters (base64) long auth key (192 bits of total entropy). 
-3. Server calculates a hash (bcrypt) for the key and saves it to the embedded persistent k/v store, mapping to the provided client id.
-4. The auth key is returned to the client.
+1. Client makes a request for registration by providing a JSON payload containing a random string which uniquely identifies the client (clientID) and an authentication key (authKey). 
+2. Server calculates a hash (bcrypt) for the authentication key and saves it to the embedded persistent k/v store, mapping to the provided client id.
+3. On success server returns a JSON response payload with the clientID and HTTP code 201.
 
 #### Client Authentication
 

--- a/service/auth.go
+++ b/service/auth.go
@@ -76,7 +76,8 @@ func (s *Service) registerClient(w http.ResponseWriter, r *http.Request) {
 	}
 
 	clientID := data.reqData["clientID"]
-	authKey, err := s.auth.Register(clientID)
+	authKey := data.reqData["authKey"]
+	err := s.auth.Register(clientID, authKey)
 	if err != nil {
 		data.err = err.Error()
 		data.code = http.StatusBadRequest
@@ -84,7 +85,6 @@ func (s *Service) registerClient(w http.ResponseWriter, r *http.Request) {
 		s.log.Debug("registered new client", mlog.String("clientID", clientID))
 		data.code = http.StatusCreated
 		data.resData["clientID"] = clientID
-		data.resData["authKey"] = authKey
 	}
 }
 

--- a/service/auth/crypto_test.go
+++ b/service/auth/crypto_test.go
@@ -23,9 +23,9 @@ func TestNewRandomString(t *testing.T) {
 }
 
 func TestHashKey(t *testing.T) {
-	key, err := newRandomString(DefaultKeyLen)
+	key, err := newRandomString(MinKeyLen)
 	require.NoError(t, err)
-	require.Len(t, key, DefaultKeyLen)
+	require.Len(t, key, MinKeyLen)
 
 	hash, err := hashKey("")
 	require.Error(t, err)
@@ -38,9 +38,9 @@ func TestHashKey(t *testing.T) {
 }
 
 func TestCompareKeyHash(t *testing.T) {
-	key, err := newRandomString(DefaultKeyLen)
+	key, err := newRandomString(MinKeyLen)
 	require.NoError(t, err)
-	require.Len(t, key, DefaultKeyLen)
+	require.Len(t, key, MinKeyLen)
 
 	hash, err := hashKey(key)
 	require.NoError(t, err)

--- a/service/auth_test.go
+++ b/service/auth_test.go
@@ -39,7 +39,7 @@ func TestRegisterClient(t *testing.T) {
 	})
 
 	t.Run("valid response", func(t *testing.T) {
-		buf := bytes.NewBuffer([]byte(`{"clientID": "clientA"}`))
+		buf := bytes.NewBuffer([]byte(`{"clientID": "clientA", "authKey": "Ey4-H_BJA00_TVByPi8DozE12ekN3S7L"}`))
 		req, err := http.NewRequest("POST", th.apiURL+"/register", buf)
 		require.NoError(t, err)
 		req.SetBasicAuth("", th.srvc.cfg.API.Security.AdminSecretKey)
@@ -50,7 +50,7 @@ func TestRegisterClient(t *testing.T) {
 		var response map[string]string
 		err = json.NewDecoder(resp.Body).Decode(&response)
 		require.NoError(t, err)
-		require.NotEmpty(t, response["authKey"])
+		require.NotEmpty(t, response["clientID"])
 	})
 }
 
@@ -81,7 +81,8 @@ func TestWSAuthHandler(t *testing.T) {
 
 	t.Run("valid auth", func(t *testing.T) {
 		clientID := "clientA"
-		buf := bytes.NewBuffer([]byte(fmt.Sprintf(`{"clientID": "%s"}`, clientID)))
+		authKey := "Ey4-H_BJA00_TVByPi8DozE12ekN3S7L"
+		buf := bytes.NewBuffer([]byte(fmt.Sprintf(`{"clientID": "%s", "authKey": "%s"}`, clientID, authKey)))
 		req, err := http.NewRequest("POST", th.apiURL+"/register", buf)
 		require.NoError(t, err)
 		req.SetBasicAuth("", th.srvc.cfg.API.Security.AdminSecretKey)
@@ -92,8 +93,6 @@ func TestWSAuthHandler(t *testing.T) {
 		var response map[string]string
 		err = json.NewDecoder(resp.Body).Decode(&response)
 		require.NoError(t, err)
-		require.NotEmpty(t, response["authKey"])
-		authKey := response["authKey"]
 
 		token := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", clientID, authKey)))
 		require.NotEmpty(t, token)

--- a/service/random/crypto.go
+++ b/service/random/crypto.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package random
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+)
+
+// NewSecureString returns a secure random string of the given length.
+// The resulting entropy will be (6 * length) bits.
+func NewSecureString(length int) (string, error) {
+	data := make([]byte, 1+(length*4)/3)
+	if n, err := rand.Read(data); err != nil {
+		return "", err
+	} else if n != len(data) {
+		return "", fmt.Errorf("failed to read enough data")
+	}
+	return base64.RawURLEncoding.EncodeToString(data)[:length], nil
+}

--- a/service/random/crypto_test.go
+++ b/service/random/crypto_test.go
@@ -1,0 +1,23 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package random
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewSecureString(t *testing.T) {
+	str, err := NewSecureString(0)
+	require.NoError(t, err)
+	require.Empty(t, str)
+
+	for i := 1; i <= 1024; i++ {
+		str, err = NewSecureString(i)
+		require.NoError(t, err)
+		require.NotEmpty(t, str)
+		require.Len(t, str, i)
+	}
+}


### PR DESCRIPTION
#### Summary

PR changes the registration flow from server-generated to client-provided key. This lets us simplify quite a lot on the plugin (client) side especially in preparation to supporting multiple rtcd servers at once.

The client-provided auth key will use the same generation function so that we guarantee the same length/entropy.


