### PR TITLE
[MM-44118] Print version info on service startup

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -55,7 +55,7 @@ func New(cfg Config) (*Service, error) {
 		return nil, fmt.Errorf("rtcd: failed to init logger: %w", err)
 	}
 
-	s.log.Info("rtcd: starting up")
+	s.log.Info("rtcd: starting up", getVersionInfo().logFields()...)
 
 	s.store, err = store.New(cfg.Store.DataSource)
 	if err != nil {

--- a/service/version.go
+++ b/service/version.go
@@ -6,14 +6,41 @@ package service
 import (
 	"encoding/json"
 	"net/http"
+	"runtime"
 
 	"github.com/mattermost/mattermost-server/v6/shared/mlog"
 )
 
 var (
-	version   = "0.1.0"
-	buildHash string
+	buildVersion string
+	buildHash    string
+	buildDate    string
 )
+
+type versionInfo struct {
+	BuildDate    string `json:"buildDate"`
+	BuildVersion string `json:"buildVersion"`
+	BuildHash    string `json:"buildHash"`
+	GoVersion    string `json:"goVersion"`
+}
+
+func getVersionInfo() versionInfo {
+	return versionInfo{
+		BuildDate:    buildDate,
+		BuildVersion: buildVersion,
+		BuildHash:    buildHash,
+		GoVersion:    runtime.Version(),
+	}
+}
+
+func (v versionInfo) logFields() []mlog.Field {
+	return []mlog.Field{
+		mlog.String("buildDate", v.BuildDate),
+		mlog.String("buildVersion", v.BuildVersion),
+		mlog.String("buildHash", v.BuildHash),
+		mlog.String("goVersion", v.GoVersion),
+	}
+}
 
 func (s *Service) getVersion(w http.ResponseWriter, req *http.Request) {
 	if req.Method != http.MethodGet {
@@ -21,13 +48,8 @@ func (s *Service) getVersion(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	version := map[string]string{
-		"version": version,
-		"build":   buildHash,
-	}
-
 	w.Header().Add("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(version); err != nil {
+	if err := json.NewEncoder(w).Encode(getVersionInfo()); err != nil {
 		s.log.Error("failed to encode data", mlog.Err(err))
 	}
 }


### PR DESCRIPTION
#### Summary

PR adds a log statement with build version information on service startup.

I also removed the hard-coded version string as it's a bit cumbersome to keep up to date and not sure if we ever need that in the first place. Going with git tags may be sufficient.

#### Sample output 

```
info  [2022-05-12 09:38:15.877 +02:00] rtcd: starting up                             caller="service/service.go:58" buildDate="2022-05-12 09:38" buildVersion=dev-432dad0 buildHash=432dad0 goVersion=go1.18.1
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44118
