### PR TITLE
[fix] Makefile no need to run go-build before docker-build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ lint: go-lint go-mod-check docker-lint ## to lint all
 test: go-test ## to test all
 
 .PHONY: docker-build
-docker-build: go-build ## to build the docker image
+docker-build: ## to build the docker image
 	@$(INFO) Performing Docker build...
 	$(AT)$(DOCKER) build -f ${DOCKER_FILE} . \
 	-t ${APP_NAME}:${APP_VERSION} || ${FAIL}


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
No need to run go-build before docker-build. Build happens within the Dockerfile
https://github.com/mattermost/rtcd/blob/master/build/Dockerfile#L13

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/DOPS-908

