### PR TITLE
[MM-44126] Implement `/stats` API endpoint

### DIFF
--- a/service/audit.go
+++ b/service/audit.go
@@ -15,7 +15,14 @@ type httpData struct {
 	err     string
 	code    int
 	reqData map[string]string
-	resData map[string]string
+	resData map[string]interface{}
+}
+
+func newHTTPData() *httpData {
+	return &httpData{
+		reqData: map[string]string{},
+		resData: map[string]interface{}{},
+	}
 }
 
 func (s *Service) httpAudit(handler string, data *httpData, w http.ResponseWriter, r *http.Request) {

--- a/service/auth.go
+++ b/service/auth.go
@@ -13,11 +13,7 @@ import (
 
 func (s *Service) authHandler(w http.ResponseWriter, r *http.Request) (clientID string, code int, err error) {
 	defer func() {
-		data := &httpData{
-			reqData: map[string]string{},
-			resData: map[string]string{},
-		}
-
+		data := newHTTPData()
 		data.code = code
 		if err != nil {
 			data.err = err.Error()
@@ -54,10 +50,7 @@ func (s *Service) registerClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := &httpData{
-		reqData: map[string]string{},
-		resData: map[string]string{},
-	}
+	data := newHTTPData()
 	defer s.httpAudit("registerClient", data, w, r)
 
 	if !s.cfg.API.Security.AllowSelfRegistration {
@@ -94,10 +87,7 @@ func (s *Service) unregisterClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	data := &httpData{
-		reqData: map[string]string{},
-		resData: map[string]string{},
-	}
+	data := newHTTPData()
 	defer s.httpAudit("unregisterClient", data, w, r)
 
 	_, code, err := s.authHandler(w, r)

--- a/service/perf/metrics.go
+++ b/service/perf/metrics.go
@@ -22,6 +22,7 @@ type Metrics struct {
 	RTPPacketCounters      *prometheus.CounterVec
 	RTPPacketBytesCounters *prometheus.CounterVec
 	RTCSessions            *prometheus.GaugeVec
+	RTCCalls               *prometheus.GaugeVec
 	RTCConnStateCounters   *prometheus.CounterVec
 	RTCErrors              *prometheus.CounterVec
 
@@ -71,9 +72,20 @@ func NewMetrics(namespace string, registry *prometheus.Registry) *Metrics {
 			Name:      "sessions_total",
 			Help:      "Total number of active RTC sessions",
 		},
-		[]string{"groupID", "callID"},
+		[]string{"groupID"},
 	)
 	m.registry.MustRegister(m.RTCSessions)
+
+	m.RTCCalls = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Namespace: namespace,
+			Subsystem: metricsSubSystemRTC,
+			Name:      "calls_total",
+			Help:      "Total number of active calls",
+		},
+		[]string{"groupID"},
+	)
+	m.registry.MustRegister(m.RTCCalls)
 
 	m.RTCConnStateCounters = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -122,12 +134,20 @@ func NewMetrics(namespace string, registry *prometheus.Registry) *Metrics {
 	return &m
 }
 
-func (m *Metrics) IncRTCSessions(groupID string, callID string) {
-	m.RTCSessions.With(prometheus.Labels{"groupID": groupID, "callID": callID}).Inc()
+func (m *Metrics) IncRTCSessions(groupID string) {
+	m.RTCSessions.With(prometheus.Labels{"groupID": groupID}).Inc()
 }
 
-func (m *Metrics) DecRTCSessions(groupID string, callID string) {
-	m.RTCSessions.With(prometheus.Labels{"groupID": groupID, "callID": callID}).Dec()
+func (m *Metrics) DecRTCSessions(groupID string) {
+	m.RTCSessions.With(prometheus.Labels{"groupID": groupID}).Dec()
+}
+
+func (m *Metrics) IncRTCCalls(groupID string) {
+	m.RTCCalls.With(prometheus.Labels{"groupID": groupID}).Inc()
+}
+
+func (m *Metrics) DecRTCCalls(groupID string) {
+	m.RTCCalls.With(prometheus.Labels{"groupID": groupID}).Dec()
 }
 
 func (m *Metrics) IncRTCConnState(state string) {

--- a/service/rtc/metrics.go
+++ b/service/rtc/metrics.go
@@ -4,8 +4,10 @@
 package rtc
 
 type Metrics interface {
-	IncRTCSessions(groupID string, callID string)
-	DecRTCSessions(groupID string, callID string)
+	IncRTCSessions(groupID string)
+	DecRTCSessions(groupID string)
+	IncRTCCalls(groupID string)
+	DecRTCCalls(groupID string)
 	IncRTCConnState(state string)
 	IncRTPPackets(direction, trackType string)
 	AddRTPPacketBytes(direction, trackType string, value int)

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -76,6 +76,7 @@ func (s *Server) addSession(cfg SessionConfig, peerConn *webrtc.PeerConnection, 
 			sessions: map[string]*session{},
 		}
 		g.calls[c.id] = c
+		s.metrics.IncRTCCalls(g.id)
 	}
 	g.mut.Unlock()
 

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -88,7 +88,7 @@ func initInterceptors(m *webrtc.MediaEngine) (*interceptor.Registry, error) {
 }
 
 func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
-	s.metrics.IncRTCSessions(cfg.GroupID, cfg.CallID)
+	s.metrics.IncRTCSessions(cfg.GroupID)
 
 	peerConnConfig := webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
@@ -372,7 +372,7 @@ func (s *Server) CloseSession(sessionID string) error {
 		return nil
 	}
 
-	s.metrics.DecRTCSessions(cfg.GroupID, cfg.CallID)
+	s.metrics.DecRTCSessions(cfg.GroupID)
 
 	group := s.getGroup(cfg.GroupID)
 	if group == nil {
@@ -394,6 +394,7 @@ func (s *Server) CloseSession(sessionID string) error {
 	delete(call.sessions, cfg.SessionID)
 	if len(call.sessions) == 0 {
 		group.mut.Lock()
+		s.metrics.DecRTCCalls(group.id)
 		delete(group.calls, cfg.CallID)
 		if len(group.calls) == 0 {
 			s.mut.Lock()

--- a/service/service.go
+++ b/service/service.go
@@ -90,6 +90,7 @@ func New(cfg Config) (*Service, error) {
 	}
 
 	s.apiServer.RegisterHandleFunc("/version", s.getVersion)
+	s.apiServer.RegisterHandleFunc("/stats", s.getStats)
 	s.apiServer.RegisterHandleFunc("/register", s.registerClient)
 	s.apiServer.RegisterHandleFunc("/unregister", s.unregisterClient)
 	s.apiServer.RegisterHandler("/ws", s.wsServer)

--- a/service/stats.go
+++ b/service/stats.go
@@ -1,0 +1,58 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	model "github.com/prometheus/client_model/go"
+)
+
+func (s *Service) getStats(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.NotFound(w, r)
+		return
+	}
+
+	data := newHTTPData()
+	defer s.httpAudit("getStats", data, w, r)
+
+	clientID, code, err := s.authHandler(w, r)
+	if err != nil {
+		data.err = err.Error()
+		data.code = code
+		return
+	}
+
+	var m = &model.Metric{}
+
+	metric, err := s.metrics.RTCCalls.GetMetricWith(prometheus.Labels{"groupID": clientID})
+	if err != nil {
+		data.err = err.Error()
+		data.code = http.StatusInternalServerError
+		return
+	}
+	if err := metric.Write(m); err != nil {
+		data.err = err.Error()
+		data.code = http.StatusInternalServerError
+		return
+	}
+	data.resData["calls"] = m.Gauge.GetValue()
+
+	metric, err = s.metrics.RTCSessions.GetMetricWith(prometheus.Labels{"groupID": clientID})
+	if err != nil {
+		data.err = err.Error()
+		data.code = http.StatusInternalServerError
+		return
+	}
+	if err := metric.Write(m); err != nil {
+		data.err = err.Error()
+		data.code = http.StatusInternalServerError
+		return
+	}
+	data.resData["sessions"] = m.Gauge.GetValue()
+
+	data.code = http.StatusOK
+}

--- a/service/stats_test.go
+++ b/service/stats_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package service
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetStats(t *testing.T) {
+	th := SetupTestHelper(t)
+	defer th.Teardown()
+
+	t.Run("invalid method", func(t *testing.T) {
+		resp, err := http.Post(th.apiURL+"/stats", "", nil)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusNotFound, resp.StatusCode)
+	})
+
+	t.Run("valid response", func(t *testing.T) {
+		req, err := http.NewRequest(http.MethodGet, th.apiURL+"/stats", nil)
+		require.NoError(t, err)
+		req.SetBasicAuth(th.adminClient.cfg.ClientID, th.adminClient.cfg.AuthKey)
+		resp, err := http.DefaultClient.Do(req)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		defer resp.Body.Close()
+		var data map[string]interface{}
+		err = json.NewDecoder(resp.Body).Decode(&data)
+		require.NoError(t, err)
+		require.Equal(t, float64(0), data["calls"])
+		require.Equal(t, float64(0), data["sessions"])
+	})
+}


### PR DESCRIPTION
#### Summary

PR adds a new `/stats` API endpoint to let clients fetch some statistics such as number of active sessions and calls. This will be particularly useful on the plugin side to determine which rtcd server to pick when load balancing between multiple hosts.

Returned stats are implicitly scoped by clientID as we leverage the existing prometheus metrics but I could see us adding global counters as well, just needs some more work.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44126