### PR TITLE
[MM-44322] Pass configured ICEServers to peer connection

### DIFF
--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -93,7 +93,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 	peerConnConfig := webrtc.Configuration{
 		ICEServers: []webrtc.ICEServer{
 			{
-				URLs: []string{},
+				URLs: s.cfg.ICEServers,
 			},
 		},
 		SDPSemantics: webrtc.SDPSemanticsUnifiedPlanWithFallback,


### PR DESCRIPTION
#### Summary

At some point we stopped passing ice servers (e.g. STUN urls) to the peer connection which meant server reflexive candidates were no longer generated. This is perfectly fine given we expect direct connectivity to be possible through the configured UDP port but if that's not the case there's still a chance things could work through the `srflx` candidate. 

This is likely what caused [this issue](https://github.com/mattermost/mattermost-plugin-calls/issues/73).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44322