### PR TITLE
[fix] makefile docker-login

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -185,7 +185,7 @@ docker-lint: ## to lint the Dockerfile
 .PHONY: docker-login
 docker-login: ## to login to a container registry
 	@$(INFO) Dockerd login to container registry ${DOCKER_REGISTRY}...
-	@echo -n "${DOCKER_PASSWORD}" | $(DOCKER) login --password-stdin -u ${DOCKER_USER} $(DOCKER_REGISTRY) || ${FAIL}
+	$(AT) echo "${DOCKER_PASSWORD}" | $(DOCKER) login --password-stdin -u ${DOCKER_USER} $(DOCKER_REGISTRY) || ${FAIL}
 	@$(OK) Dockerd login to container registry ${DOCKER_REGISTRY}...
 
 go-build: $(GO_BUILD_PLATFORMS_ARTIFACTS) ## to build binaries


### PR DESCRIPTION
- adding verbosity control for docker-login target
- removing unneeded `-n` option from echo

```
 -n    Do not print the trailing newline character.  This may also be achieved by appending ‘\c’ to the end of the string, as is
           done by iBCS2 compatible systems.  Note that this option as well as the effect of ‘\c’ are implementation-defined in IEEE Std
           1003.1-2001 (“POSIX.1”) as amended by Cor. 1-2002.  Applications aiming for maximum portability are strongly encouraged to
           use printf(1) to suppress the newline character.
```

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/DOPS-908
