### PR TITLE
[fix] Makefile docker-sign

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -139,13 +139,14 @@ docker-sign: ## to sign the docker image
 	$(AT)echo "$${COSIGN_KEY}" > cosign.key && \
 	$(DOCKER) run ${DOCKER_OPTS} \
 	--entrypoint '/bin/sh' \
+        -v $(PWD):/app -w /app \
 	-e COSIGN_PASSWORD=${COSIGN_PASSWORD} \
 	-e HOME="/tmp" \
     ${DOCKER_IMAGE_COSIGN} \
 	-c \
-	echo "Signing..." && \
+	"echo Signing... && \
 	cosign login $(DOCKER_REGISTRY) -u ${DOCKER_USER} -p ${DOCKER_PASSWORD} && \
-	cosign sign --key cosign.key $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION} || ${FAIL}
+	cosign sign --key cosign.key $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION}" || ${FAIL}
 	$(AT)rm -f cosign.key || ${FAIL}
 	@$(OK) Signing the docker image: $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION}
 
@@ -155,7 +156,8 @@ docker-verify: ## to verify the docker image
 	$(AT)echo "$${COSIGN_PUBLIC_KEY}" > cosign_public.key && \
 	$(DOCKER) run ${DOCKER_OPTS} \
 	--entrypoint '/bin/sh' \
-    ${DOCKER_IMAGE_COSIGN} \
+        -v $(PWD):/app -w /app \
+        ${DOCKER_IMAGE_COSIGN} \
 	-c \
 	echo "Verifying..." && \
 	cosign verify --key cosign_public.key $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION} || ${FAIL}


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
This fixes the docker-sign target.

Cosign binary, was escaped and did not run inside the cosign dedicated container.
Moreover, we need the cosign key variable to be exposed in the container as a file.
Therefore we mount the required volumes


#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/DOPS-908
