### PR TITLE
[fix] Makefile docker-verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -159,8 +159,8 @@ docker-verify: ## to verify the docker image
         -v $(PWD):/app -w /app \
         ${DOCKER_IMAGE_COSIGN} \
 	-c \
-	echo "Verifying..." && \
-	cosign verify --key cosign_public.key $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION} || ${FAIL}
+	"echo Verifying... && \
+	cosign verify --key cosign_public.key $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION}" || ${FAIL}
 	$(AT)rm -f cosign_public.key || ${FAIL}
 	@$(OK) Verifying the published docker image: $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}/${APP_NAME}:${APP_VERSION}
 


### PR DESCRIPTION
This fixes the `docker-verify` target which is affected by the same bug as described https://github.com/mattermost/rtcd/pull/40 
Cosign binary, was escaped and did not run inside the cosign dedicated container.


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/DOPS-908
