### PR TITLE
[feat] Makefile go-test refactor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ DOCKER_REGISTRY_REPO    += mattermost
 DOCKER_USER             ?= user
 DOCKER_PASSWORD         ?= password
 ## Docker Images
+DOCKER_IMAGE_GO         += "golang:${GO_VERSION}@sha256:79138c839452a2a9d767f0bba601bd5f63af4a1d8bb645bf6141bff8f4f33bb8"
 DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.45.2@sha256:e84b639c061c8888be91939c78dae9b1525359954e405ab0d9868a46861bd21b"
 DOCKER_IMAGE_DOCKERLINT += "hadolint/hadolint:v2.9.2@sha256:d355bd7df747a0f124f3b5e7b21e9dafd0cb19732a276f901f0fdee243ec1f3b"
 DOCKER_IMAGE_COSIGN     += "bitnami/cosign:1.8.0@sha256:8c2c61c546258fffff18b47bb82a65af6142007306b737129a7bd5429d53629a"
@@ -37,6 +38,8 @@ COSIGN_PASSWORD         ?= password
 ## Go Variables
 # Go executable
 GO                           := $(shell which go)
+# Extract GO version from go.mod file
+GO_VERSION                   ?= $(shell grep -E '^go' go.mod | awk {'print $$2'})
 # LDFLAGS
 GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildHash=$(APP_COMMIT)"
 GO_LDFLAGS                   += -X "github.com/mattermost/${APP_NAME}/service.buildVersion=$(APP_VERSION)"
@@ -122,7 +125,9 @@ test: go-test ## to test all
 .PHONY: docker-build
 docker-build: ## to build the docker image
 	@$(INFO) Performing Docker build ${APP_NAME}:${APP_VERSION}...
-	$(AT)$(DOCKER) build -f ${DOCKER_FILE} . \
+	$(AT)$(DOCKER) build \
+	--build-arg GO_IMAGE=${DOCKER_IMAGE_GO} \
+	-f ${DOCKER_FILE} . \
 	-t ${APP_NAME}:${APP_VERSION} || ${FAIL}
 	@$(OK) Performing Docker build ${APP_NAME}:${APP_VERSION}
 
@@ -219,7 +224,13 @@ go-run: ## to run locally for development
 .PHONY: go-test
 go-test: ## to run tests
 	@$(INFO) testing...
-	$(AT)$(GO) test ${GO_TEST_OPTS} ./... || ${FAIL}
+	$(AT)$(DOCKER) run ${DOCKER_OPTS} \
+	-v $(PWD):/app -w /app \
+	-e GOCACHE="/tmp" \
+	$(DOCKER_IMAGE_GO) \
+	/bin/sh -c \
+	"cd /app && \
+	go test ${GO_TEST_OPTS} ./... " || ${FAIL}
 	@$(OK) testing
 
 .PHONY: go-mod-check

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,9 @@
 # This dockerfile is used to build Mattermost rtcd
-# A multi stage build, with golang:1.17.9-alpine used as a builder
+# A multi stage build, with golang used as a builder
 # and gcr.io/distroless/static as runner
-FROM golang:1.17.9-alpine@sha256:5c2fcfeb58ad9d4948d94e7b2d0432a9bc38bee0f8dfb41d383f38a18b75c38d as builder
+ARG GO_IMAGE=golang:1.17@sha256:79138c839452a2a9d767f0bba601bd5f63af4a1d8bb645bf6141bff8f4f33bb8
+# hadolint ignore=DL3006
+FROM ${GO_IMAGE} as builder
 
 #GO_BUILD_PLATFORMS holds the platforms that we will build the docker image against
 ARG GO_BUILD_PLATFORMS=linux-amd64
@@ -9,12 +11,7 @@ ARG GO_BUILD_PLATFORMS=linux-amd64
 # Setup directories structure and compile
 COPY . /src
 WORKDIR /src
-RUN apk add \
-    coreutils=9.0-r2 \
-    make=4.3-r0 \
-    git=2.34.2-r0 \
-    --no-cache \
-    && make go-build
+RUN make go-build
 
 # Shrink final image since we only need the rtcd binary
 # and use distroless container image as runner for security


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- **Makefile:** Migrating `go-test` target, to running under a container, thus decoupling from local system
- **Makefile:** Dynamically extracting and using Go Version from go.mod file
- **Dockerfile**: Using `golang:1.17` instead of `golang:1.17-alpine` for `builder` stage. Thus removing the dependency of maintaining a list of packages. 
Dockerfile step: 
```
  RUN apk add \
    coreutils=9.0-r2 \
    make=4.3-r0 \
    git=2.34.2-r0 \
    --no-cache
```

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/DOPS-908
