### PR TITLE
[fix] makefile app_version logic

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,10 +62,10 @@ CURRENT_BRANCH   := $(shell git rev-parse --abbrev-ref HEAD)
 APP_NAME    := $(shell basename -s .git `git config --get remote.origin.url`)
 # Get current commit
 APP_COMMIT  := $(shell git log --pretty=format:'%h' -n 1)
-# Check if we are in a release tag, if yes use it as app version, else use dev-sha as app version
-APP_VERSION := $(shell git describe --abbrev=0 --exact-match --tags > /dev/null 2>&1 || echo dev-$(APP_COMMIT))
-# Check if we are in protected branch, if yes use latest as app version.
-APP_VERSION := $(shell if [ $(PROTECTED_BRANCH) = $(CURRENT_BRANCH) ]; then echo latest; else echo $(APP_VERSION) ; fi)
+# Check if we are in protected branch, if yes use `latest` as app version.
+# Else check if we are in a release tag, if yes use the tag as app version, else use `dev-sha` as app version
+APP_VERSION := $(shell if [ $(PROTECTED_BRANCH) = $(CURRENT_BRANCH) ]; then echo latest; else (git describe --abbrev=0 --exact-match --tags || echo dev-$(APP_COMMIT)) ; fi)
+
 # Get current date and format like: 2022-04-27 11:32
 BUILD_DATE  := $(shell date +%Y-%m-%d\ %H:%M)
 


### PR DESCRIPTION


<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->

We are fixing the logic to extract the APP_VERSION.

Specifically, we are checking if we are in protected branch, if yes use we use `latest` as app version.
Else we are checking if we are in a release tag, if yes we are using tag as app version
Else we use `dev-sha` as app version

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
Ticket: https://mattermost.atlassian.net/browse/DOPS-908
