### PR TITLE
[MM-44897] Add draining wait on RTC server stop

### DIFF
--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -367,6 +367,13 @@ func (s *Server) CloseSession(sessionID string) error {
 	s.mut.Lock()
 	cfg, ok := s.sessions[sessionID]
 	delete(s.sessions, sessionID)
+
+	if len(s.sessions) == 0 && s.drainCh != nil {
+		s.log.Debug("closing drain channel")
+		close(s.drainCh)
+		s.drainCh = nil
+	}
+
 	s.mut.Unlock()
 	if !ok {
 		return nil


### PR DESCRIPTION
#### Summary

We make stopping the RTC server a blocking operation so that we make sure to drain the instance and exit only when all call sessions are done. 

/cc @angeloskyratzakos 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44897

