### PR TITLE
[MM-44486] Use proper ICE server configs

### DIFF
--- a/docs/env_config.md
+++ b/docs/env_config.md
@@ -11,7 +11,7 @@ RTCD_API_SECURITY_ADMINSECRETKEY           String
 RTCD_API_SECURITY_ALLOWSELFREGISTRATION    True or False
 RTCD_RTC_ICEPORTUDP                        Integer
 RTCD_RTC_ICEHOSTOVERRIDE                   String
-RTCD_RTC_ICESERVERS                        Comma-separated list of String
+RTCD_RTC_ICESERVERS                        Comma-separated list of 
 RTCD_STORE_DATASOURCE                      String
 RTCD_LOGGER_ENABLECONSOLE                  True or False
 RTCD_LOGGER_CONSOLEJSON                    True or False

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -80,7 +80,5 @@ func New(config Config) (*mlog.Logger, error) {
 		return nil, err
 	}
 
-	logger.RedirectStdLog(mlog.LvlStdLog)
-
 	return logger, nil
 }

--- a/service/rtc/config.go
+++ b/service/rtc/config.go
@@ -104,3 +104,37 @@ func (s ICEServers) getSTUN() string {
 	}
 	return ""
 }
+
+func (s *ICEServers) UnmarshalTOML(data interface{}) error {
+	d, ok := data.([]interface{})
+	if !ok {
+		return fmt.Errorf("invalid type %T", data)
+	}
+
+	var iceServers []ICEServerConfig
+	for _, obj := range d {
+		var server ICEServerConfig
+
+		switch t := obj.(type) {
+		case string:
+			server.URLs = append(server.URLs, obj.(string))
+		case map[string]interface{}:
+			m := obj.(map[string]interface{})
+			urls, _ := m["urls"].([]interface{})
+			for _, u := range urls {
+				uVal, _ := u.(string)
+				server.URLs = append(server.URLs, uVal)
+			}
+			server.Username, _ = m["username"].(string)
+			server.Credential, _ = m["credential"].(string)
+		default:
+			return fmt.Errorf("unknown type %T", t)
+		}
+
+		iceServers = append(iceServers, server)
+	}
+
+	*s = iceServers
+
+	return nil
+}

--- a/service/rtc/config.go
+++ b/service/rtc/config.go
@@ -4,6 +4,7 @@
 package rtc
 
 import (
+	"encoding/json"
 	"fmt"
 	"strings"
 )
@@ -103,6 +104,24 @@ func (s ICEServers) getSTUN() string {
 		}
 	}
 	return ""
+}
+
+func (s *ICEServers) Decode(value string) error {
+	fmt.Println(value)
+
+	var urls []string
+	err := json.Unmarshal([]byte(value), &urls)
+	if err == nil {
+		iceServers := []ICEServerConfig{
+			{
+				URLs: urls,
+			},
+		}
+		*s = iceServers
+		return nil
+	}
+
+	return json.Unmarshal([]byte(value), s)
 }
 
 func (s *ICEServers) UnmarshalTOML(data interface{}) error {

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -83,7 +83,7 @@ func (s *Server) ReceiveCh() <-chan Message {
 
 func (s *Server) Start() error {
 	if s.cfg.ICEHostOverride == "" && len(s.cfg.ICEServers) > 0 {
-		addr, err := getPublicIP(s.cfg.ICEPortUDP, s.cfg.ICEServers)
+		addr, err := getPublicIP(s.cfg.ICEPortUDP, s.cfg.ICEServers.getSTUN())
 		if err != nil {
 			return fmt.Errorf("failed to get public IP address: %w", err)
 		}

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -90,12 +90,16 @@ func initInterceptors(m *webrtc.MediaEngine) (*interceptor.Registry, error) {
 func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 	s.metrics.IncRTCSessions(cfg.GroupID, cfg.CallID)
 
+	iceServers := make([]webrtc.ICEServer, len(s.cfg.ICEServers))
+	for _, cfg := range s.cfg.ICEServers {
+		iceServers = append(iceServers, webrtc.ICEServer{
+			URLs:       cfg.URLs,
+			Username:   cfg.Username,
+			Credential: cfg.Credential,
+		})
+	}
 	peerConnConfig := webrtc.Configuration{
-		ICEServers: []webrtc.ICEServer{
-			{
-				URLs: s.cfg.ICEServers,
-			},
-		},
+		ICEServers:   iceServers,
 		SDPSemantics: webrtc.SDPSemanticsUnifiedPlanWithFallback,
 	}
 

--- a/service/rtc/stun.go
+++ b/service/rtc/stun.go
@@ -12,7 +12,11 @@ import (
 	"github.com/pion/stun"
 )
 
-func getPublicIP(port int, iceServers []string) (string, error) {
+func getPublicIP(port int, stunURL string) (string, error) {
+	if stunURL == "" {
+		return "", fmt.Errorf("no STUN server URL was provided")
+	}
+
 	conn, err := net.ListenUDP("udp4", &net.UDPAddr{
 		Port: port,
 	})
@@ -21,15 +25,6 @@ func getPublicIP(port int, iceServers []string) (string, error) {
 	}
 	defer conn.Close()
 
-	var stunURL string
-	for _, u := range iceServers {
-		if strings.HasPrefix(u, "stun:") {
-			stunURL = u
-		}
-	}
-	if stunURL == "" {
-		return "", fmt.Errorf("no STUN server URL was found")
-	}
 	serverURL := stunURL[strings.Index(stunURL, ":")+1:]
 	serverAddr, err := net.ResolveUDPAddr("udp", serverURL)
 	if err != nil {


### PR DESCRIPTION
#### Summary

Changing `ServerConfig.ICEServers` to be a list of proper ICE server config, potentially supporting TURN servers as well, which need credentials.

**Note**

This is a breaking change but it's one we can afford to make on this side. I've also added a backwards compatible unmarshaler for the config so that we can still support the previous format, just in case.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-44486