### PR TITLE
[fix] Makefile, tagging master instead of master-sha

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ APP_NAME    := $(shell basename -s .git `git config --get remote.origin.url`)
 APP_COMMIT  := $(shell git log --pretty=format:'%h' -n 1)
 # Check if we are in protected branch, if yes use `protected_branch_name-sha` as app version.
 # Else check if we are in a release tag, if yes use the tag as app version, else use `dev-sha` as app version.
-APP_VERSION ?= $(shell if [ $(PROTECTED_BRANCH) = $(CURRENT_BRANCH) ]; then echo $(PROTECTED_BRANCH)-$(APP_COMMIT); else (git describe --abbrev=0 --exact-match --tags 2>/dev/null || echo dev-$(APP_COMMIT)) ; fi)
+APP_VERSION ?= $(shell if [ $(PROTECTED_BRANCH) = $(CURRENT_BRANCH) ]; then echo $(PROTECTED_BRANCH); else (git describe --abbrev=0 --exact-match --tags 2>/dev/null || echo dev-$(APP_COMMIT)) ; fi)
 
 # Get current date and format like: 2022-04-27 11:32
 BUILD_DATE  := $(shell date +%Y-%m-%d\ %H:%M)


### PR DESCRIPTION

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
If we run under protected branch, tag `master` instead of `master-sha`
In that way, the latest master will be available in the dev dockerhub repository





