### PR TITLE
[MM-45150] Fix failing to add tracks due to full channel

### DIFF
--- a/service/client.go
+++ b/service/client.go
@@ -267,6 +267,12 @@ func (c *Client) Close() error {
 }
 
 func (c *Client) sendError(err error) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	if c.closed {
+		return
+	}
+
 	select {
 	case c.errorCh <- err:
 	default:

--- a/service/client.go
+++ b/service/client.go
@@ -18,7 +18,6 @@ import (
 )
 
 const (
-	msgChSize                = 64
 	maxReconnectInterval     = 30 * time.Second
 	defaultReconnectInterval = 2 * time.Second
 )
@@ -46,8 +45,8 @@ func NewClient(cfg ClientConfig, opts ...ClientOption) (*Client, error) {
 		return nil, fmt.Errorf("failed to parse config: %w", err)
 	}
 	c.cfg = &cfg
-	c.receiveCh = make(chan ClientMessage, msgChSize)
-	c.errorCh = make(chan error)
+	c.receiveCh = make(chan ClientMessage, ws.ReceiveChSize)
+	c.errorCh = make(chan error, 32)
 
 	for _, opt := range opts {
 		if err := opt(&c); err != nil {
@@ -271,7 +270,7 @@ func (c *Client) sendError(err error) {
 	select {
 	case c.errorCh <- err:
 	default:
-		log.Printf("failed to send error: channel is full")
+		log.Printf("failed to send error: channel is full: %s", err.Error())
 	}
 }
 

--- a/service/ws/client.go
+++ b/service/ws/client.go
@@ -5,6 +5,7 @@ package ws
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -42,8 +43,8 @@ func NewClient(cfg ClientConfig, opts ...ClientOption) (*Client, error) {
 	c := &Client{
 		cfg:       cfg,
 		sendCh:    make(chan Message, sendChSize),
-		receiveCh: make(chan Message, receiveChSize),
-		errorCh:   make(chan error),
+		receiveCh: make(chan Message, ReceiveChSize),
+		errorCh:   make(chan error, 32),
 	}
 
 	for _, opt := range opts {
@@ -149,6 +150,7 @@ func (c *Client) sendError(err error) {
 	select {
 	case c.errorCh <- err:
 	default:
+		log.Printf("failed to send error: channel is full: %s", err.Error())
 	}
 }
 

--- a/service/ws/server.go
+++ b/service/ws/server.go
@@ -16,8 +16,8 @@ import (
 )
 
 const (
-	sendChSize    = 256
-	receiveChSize = 256
+	ReceiveChSize = 512
+	sendChSize    = ReceiveChSize
 	writeWaitTime = 10 * time.Second
 )
 
@@ -45,7 +45,7 @@ func NewServer(cfg ServerConfig, log mlog.LoggerIFace, opts ...ServerOption) (*S
 		log:       log,
 		conns:     make(map[string]*conn),
 		sendCh:    make(chan Message, sendChSize),
-		receiveCh: make(chan Message, receiveChSize),
+		receiveCh: make(chan Message, ReceiveChSize),
 	}
 
 	for _, opt := range opts {


### PR DESCRIPTION
#### Summary

It took a while to debug this cause it wasn't clear at which level the problem was happening (client vs mattermost server vs plugin vs rtcd). Initial inspection of the logs at the various levels indicated that some clients failed to receive websocket events related to voice tracks which resulted in them not hearing some unmuted participants. In fact, when someone unmutes we loop through all connections to broadcast the necessary events that eventually get the voice track to the client.

There were around 130 participants in COM yesterday. One of those unmuting caused 130 track events to get sent down a channel of buffer 64 which wasn't able to handle them all in time and got full. Eventually messages for about 4/5 users were dropped. 

Finding an ideal value is a hard problem of course and we certainly don't want to make the operation blocking but it looks like that, to be on the safe side, the buffer size should roughly be equal to the maximum burst of events we expect which roughly translates into the maximum number of participants in a call. Of course it's a little more complex than this since multiple calls can live on a single rtcd instance but unmuting events for separate calls are unlikely to happen simultaneously. I think we are bumping them sufficiently high here but will keep monitoring in case they needs further tuning.

Issues addressed in this PR:

- Making client error channels buffered.
- Logging out the original error in case the error channel gets full so we don't lose possibly valuable information.
- Setting the client receive channel size to match the websocket one since they are tightly coupled. By client here we mean the rtcd client on the plugin side which potentially could handle multiple calls and hundreds of connected users.

Once this is merged I'll tag it and create one on the plugin side since these are client related changes so will need to a new plugin release.

Special thanks to @agnivade for providing client-side logs that helped me debugging this. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45150
