### PR TITLE
service/rtc: Fixing repeat initialization of connection

### DIFF
--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -154,10 +154,11 @@ func (s *Server) Start() error {
 		}
 
 		conns = append(conns, udpConn)
-		s.udpConn, err = newMultiConn(conns)
-		if err != nil {
-			return fmt.Errorf("failed to create multiconn: %w", err)
-		}
+	}
+	var err error
+	s.udpConn, err = newMultiConn(conns)
+	if err != nil {
+		return fmt.Errorf("failed to create multiconn: %w", err)
 	}
 
 	s.udpMux = webrtc.NewICEUDPMux(nil, s.udpConn)


### PR DESCRIPTION
MultiConn was being incorrectly initialized inside a loop.
This created repeated listener goroutines of the same connection.
