### PR TITLE
MM-47231 - Secure the /unregister api path

### DIFF
--- a/service/client_test.go
+++ b/service/client_test.go
@@ -84,7 +84,7 @@ func TestNewClient(t *testing.T) {
 }
 
 func TestClientRegister(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	c, err := NewClient(ClientConfig{
@@ -159,7 +159,7 @@ func TestClientRegister(t *testing.T) {
 }
 
 func TestClientUnregister(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	c, err := NewClient(ClientConfig{
@@ -209,7 +209,7 @@ func TestClientUnregister(t *testing.T) {
 }
 
 func TestClientConnect(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	c, err := NewClient(ClientConfig{URL: th.apiURL})
@@ -263,7 +263,7 @@ func TestClientConnect(t *testing.T) {
 }
 
 func TestClientSend(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	clientID := "clientA"
@@ -327,7 +327,7 @@ func TestClientSend(t *testing.T) {
 }
 
 func TestClientReceive(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	clientID := "clientA"
@@ -393,7 +393,7 @@ func TestClientReceive(t *testing.T) {
 }
 
 func TestClientReconnect(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	clientID := "clientA"
@@ -500,7 +500,7 @@ func TestClientReconnect(t *testing.T) {
 }
 
 func TestClientCloseReconnectRace(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	clientID := "clientA"
@@ -545,7 +545,7 @@ func TestClientCloseReconnectRace(t *testing.T) {
 }
 
 func TestClientConcurrency(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	clientID := "clientA"

--- a/service/version_test.go
+++ b/service/version_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestGetVersion(t *testing.T) {
-	th := SetupTestHelper(t)
+	th := SetupTestHelper(t, nil)
 	defer th.Teardown()
 
 	t.Run("invalid method", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
(just cutting and pasting the description of the problem from the channel 😄  ) :
- If client [self registration](https://github.com/mattermost/rtcd/blob/dded04f0cc2daee07ba58104c87f1422e493a0f9/config/config.sample.toml#L13) is enabled then a client can unregister itself. Right now an authenticated client can unregister any other client just by knowing their id.
- If self registration is disabled and an [admin key](https://github.com/mattermost/rtcd/blob/dded04f0cc2daee07ba58104c87f1422e493a0f9/config/config.sample.toml#L19-L21) is configured then that can unregister anyone.
- If none of the above is set (self register disabled and no admin configured) then the call should simply return forbidden.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-47231
