### PR TITLE
[MM-47933] Simplify handling of voice tracks

### DIFF
--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -31,15 +31,13 @@ func (c *call) addSession(cfg SessionConfig, rtcConn *webrtc.PeerConnection, clo
 	}
 
 	s := &session{
-		cfg:           cfg,
-		rtcConn:       rtcConn,
-		iceInCh:       make(chan []byte, signalChSize*2),
-		sdpInCh:       make(chan []byte, signalChSize),
-		closeCh:       make(chan struct{}),
-		closeCb:       closeCb,
-		tracksCh:      make(chan *webrtc.TrackLocalStaticRTP, tracksChSize),
-		trackEnableCh: make(chan bool, tracksChSize),
-		rtpSendersMap: make(map[*webrtc.TrackLocalStaticRTP]*webrtc.RTPSender),
+		cfg:      cfg,
+		rtcConn:  rtcConn,
+		iceInCh:  make(chan []byte, signalChSize*2),
+		sdpInCh:  make(chan []byte, signalChSize),
+		closeCh:  make(chan struct{}),
+		closeCb:  closeCb,
+		tracksCh: make(chan *webrtc.TrackLocalStaticRTP, tracksChSize),
 	}
 
 	c.sessions[cfg.SessionID] = s

--- a/service/rtc/utils.go
+++ b/service/rtc/utils.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net"
 	"time"
+
+	"github.com/mattermost/rtcd/service/random"
 )
 
 func resolveHost(host string, timeout time.Duration) (string, error) {
@@ -23,4 +25,8 @@ func resolveHost(host string, timeout time.Duration) (string, error) {
 		ip = addrs[0].String()
 	}
 	return ip, err
+}
+
+func genTrackID(trackType, baseID string) string {
+	return trackType + "_" + baseID + "_" + random.NewID()[0:8]
 }


### PR DESCRIPTION
#### Summary

Quite a bit happening here which I'll try to explain. First of all the main change is an overall review of voice tracks handling which led to a significant simplification of how we deal with them. 

**Problem**

Calling `rtpSender.ReplaceTrack(nil)` on the server (pion) side is not working consistently across browsers after a new negotiation happens. For example, given a call with two participants, this sequence would trigger the issue:

1. A and B join the call (order of join doesn't matter here).
2. B unmutes
3. B mutes
4. B shares screen (sharing screen is just an example, it could be any other negotiation, like some other participant unmuting for the first time).
5. B unmutes
6. A is not hearing B

It seems like Firefox is handling this better, in fact I couldn't reproduce this on that browser but if the receiver is Chrome then it happens consistently as the track is essentially killed after a negotiation happens, even though the associated receiver is actually still receiving the data ([pion/webrtc#1843](https://github.com/pion/webrtc/issues/1843) and [pion/webrtc#2226](https://github.com/pion/webrtc/issues/2226) potentially related).

So I now realize this is what led me to implement the "dummy track" approach in  https://github.com/mattermost/mattermost-plugin-calls/commit/7fe137bc4a8fc539c15662bc4dbb9fbcff740bca.

But that complicates things and with the later addition in https://github.com/mattermost/mattermost-plugin-calls/commit/0676af23136abd093ea4a7716ef956bebb98acdf even more so much that right now every first unmute (or new negotiation that is) would trigger the renegotiation of every pre-existing track that's still active (weird and completely unnecessary).

**Proposed solution**

So while I still think `ReplaceTrack(nil)` should work properly it's also true that on the server we can easily suspend sending audio packets when someone mutes, and [we are doing that already](https://github.com/mattermost/rtcd/blob/dded04f0cc2daee07ba58104c87f1422e493a0f9/service/rtc/sfu.go#L280-L287) regardless of track state.

So my proposal is to get rid of all this extra and elaborate logic and just stop sending RTP packets if the track is muted. I checked that the receiving side won't panic and it seems everything works fine, the audio track is automatically filled with silence by the client which is what we want.

I've load-tested this under various scenarios and everything looked good but obviously I'd like to get this deployed asap once merged in case there's some edge case I may have missed.

**Note**

I am not confident that these changes could have much to do with the calls-recorder issue which is still very suspect. The only thing I can try for now on that side is to update to the latest chrome version since we are still using `99.0.4844.82` which is several months out of date.

**Other included changes**

- We are now generating globally unique IDs for tracks which should make certain clients happier ;)
- I reviewed several log statements and made sure everything has at least the `sessionID` information embedded so that we can more easily trace things in case of issues.
- Fixed a potential resource leak introduced in https://github.com/mattermost/rtcd/pull/74

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/231

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-47933
