### PR TITLE
[MM-48952] Set config defaults before attempting to load from config file

### DIFF
--- a/cmd/rtcd/config.go
+++ b/cmd/rtcd/config.go
@@ -20,9 +20,11 @@ import (
 // variables corresponding to a specific setting.
 func loadConfig(path string) (service.Config, error) {
 	var cfg service.Config
+
+	cfg.SetDefaults()
+
 	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
 		log.Printf("config file not found at %s, using defaults", path)
-		cfg.SetDefaults()
 	} else if _, err := toml.DecodeFile(path, &cfg); err != nil {
 		return cfg, fmt.Errorf("failed to decode config file: %w", err)
 	}

--- a/cmd/rtcd/config_test.go
+++ b/cmd/rtcd/config_test.go
@@ -14,13 +14,14 @@ import (
 )
 
 func TestLoadConfig(t *testing.T) {
+	var defaultCfg service.Config
+	defaultCfg.SetDefaults()
+
 	t.Run("non existant file", func(t *testing.T) {
-		var testCfg service.Config
-		testCfg.SetDefaults()
 		cfg, err := loadConfig("")
 		require.NoError(t, err)
 		require.NotEmpty(t, cfg)
-		require.Equal(t, testCfg, cfg)
+		require.Equal(t, defaultCfg, cfg)
 	})
 
 	t.Run("empty file", func(t *testing.T) {
@@ -32,7 +33,7 @@ func TestLoadConfig(t *testing.T) {
 
 		cfg, err := loadConfig(file.Name())
 		require.NoError(t, err)
-		require.Empty(t, cfg)
+		require.Equal(t, defaultCfg, cfg)
 	})
 
 	t.Run("invalid config", func(t *testing.T) {
@@ -47,7 +48,7 @@ func TestLoadConfig(t *testing.T) {
 
 		cfg, err := loadConfig(file.Name())
 		require.NoError(t, err)
-		require.Empty(t, cfg)
+		require.Equal(t, defaultCfg, cfg)
 	})
 
 	t.Run("valid config", func(t *testing.T) {


### PR DESCRIPTION
#### Summary

While testing I noticed that upgrading `rtcd` could easily fail after new config settings are added (e.g. https://github.com/mattermost/rtcd/pull/75) because we are not enforcing defaults and the missing new setting would cause the service to fail. 

Setting defaults prior to loading the config file should help to avoid breaking changes while upgrading.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-48952
