### PR TITLE
Fix potential data races

### DIFF
--- a/service/audit.go
+++ b/service/audit.go
@@ -42,12 +42,13 @@ func (s *Service) httpAudit(handler string, data *httpData, w http.ResponseWrite
 }
 
 func reqAuditFields(req *http.Request) []mlog.Field {
-	delete(req.Header, "Authorization")
+	hdr := req.Header.Clone()
+	delete(hdr, "Authorization")
 	fields := []mlog.Field{
 		mlog.String("remoteAddr", req.RemoteAddr),
 		mlog.String("method", req.Method),
 		mlog.String("url", req.URL.String()),
-		mlog.Any("header", req.Header),
+		mlog.Any("header", hdr),
 		mlog.String("host", req.Host),
 	}
 	return fields


### PR DESCRIPTION
#### Summary

PR fixes a couple of potential data races:

1. Cloning HTTP requests headers to avoid reading (logging) and writing at the same time.
2. Although the underlying `bitcask` store is already safe for concurrent use, the way we use it is not since we force a sync on every write. 


