### PR TITLE
[MM-49236] Implement server side VAD

### DIFF
--- a/service/client_msg.go
+++ b/service/client_msg.go
@@ -23,6 +23,7 @@ const (
 	ClientMessageHello     = "hello"
 	ClientMessageReconnect = "reconnect"
 	ClientMessageClose     = "close"
+	ClientMessageVAD       = "vad"
 )
 
 var _ msgpack.CustomEncoder = (*ClientMessage)(nil)
@@ -47,7 +48,7 @@ func (cm *ClientMessage) DecodeMsgpack(dec *msgpack.Decoder) error {
 			return fmt.Errorf("failed to decode msg.Data: %w", err)
 		}
 		cm.Data = data
-	case ClientMessageRTC:
+	case ClientMessageRTC, ClientMessageVAD:
 		var rtcMsg rtc.Message
 		if err = dec.Decode(&rtcMsg); err != nil {
 			return fmt.Errorf("failed to decode rtc.Message: %w", err)

--- a/service/rtc/msg.go
+++ b/service/rtc/msg.go
@@ -19,12 +19,15 @@ const (
 	UnmuteMessage
 	ScreenOnMessage
 	ScreenOffMessage
+	VoiceOnMessage
+	VoiceOffMessage
 )
 
 type Message struct {
 	GroupID   string      `msgpack:"group_id"`
 	UserID    string      `msgpack:"user_id"`
 	SessionID string      `msgpack:"session_id"`
+	CallID    string      `msgpack:"call_id"`
 	Type      MessageType `msgpack:"type"`
 	Data      []byte      `msgpack:"data,omitempty"`
 }
@@ -45,7 +48,8 @@ func newMessage(s *session, msgType MessageType, data []byte) Message {
 		GroupID:   s.cfg.GroupID,
 		UserID:    s.cfg.UserID,
 		SessionID: s.cfg.SessionID,
-		Type:      ICEMessage,
+		CallID:    s.cfg.CallID,
+		Type:      msgType,
 		Data:      data,
 	}
 }

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -311,6 +311,14 @@ func (s *Server) msgReader() {
 			var enabled bool
 			if msg.Type == UnmuteMessage {
 				enabled = true
+			} else {
+				session.mut.Lock()
+				if session.vadMonitor != nil {
+					s.log.Debug("resetting vad monitor for session",
+						mlog.String("sessionID", session.cfg.SessionID))
+					session.vadMonitor.Reset()
+				}
+				session.mut.Unlock()
 			}
 
 			s.log.Debug("setting voice track state",

--- a/service/rtc/vad/vad.go
+++ b/service/rtc/vad/vad.go
@@ -150,3 +150,11 @@ func (m *Monitor) PushAudioLevel(level uint8) {
 	m.cb(newState)
 	m.voiceState = newState
 }
+
+func (m *Monitor) Reset() {
+	m.voiceLevelsSamplePtr = 0
+	m.voiceLevelsSample = m.voiceLevelsSample[:0]
+	m.lastActivationTime = time.Time{}
+	m.voiceState = false
+	m.cb(false)
+}

--- a/service/rtc/vad/vad.go
+++ b/service/rtc/vad/vad.go
@@ -133,9 +133,6 @@ func (m *Monitor) PushAudioLevel(level uint8) {
 	avg := getAvg(m.voiceLevelsSample)
 	dev := getStdDev(m.voiceLevelsSample, avg)
 
-	fmt.Printf("avg: %d\n", avg)
-	fmt.Printf("dev: %d\n", dev)
-
 	var newState bool
 	if !m.voiceState && int(dev) > m.cfg.VoiceActivationThreshold {
 		newState = true

--- a/service/rtc/vad/vad.go
+++ b/service/rtc/vad/vad.go
@@ -1,0 +1,155 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package vad
+
+import (
+	"fmt"
+	"math"
+	"time"
+)
+
+const (
+	defaultVoiceLevelsSampleSize      = 50
+	defaultVoiceActivationThreshold   = 10
+	defaultVoiceDeactivationThreshold = 4
+	defaultActivationDuration         = 2 * time.Second
+)
+
+type VoiceCB func(voice bool)
+
+type Monitor struct {
+	cfg MonitorConfig
+
+	voiceLevelsSample    []uint8
+	voiceLevelsSamplePtr int
+	lastActivationTime   time.Time
+	voiceState           bool
+	cb                   VoiceCB
+}
+
+type MonitorConfig struct {
+	VoiceLevelsSampleSize      int
+	ActivationDuration         time.Duration
+	VoiceActivationThreshold   int
+	VoiceDeactivationThreshold int
+}
+
+func (c MonitorConfig) SetDefaults() MonitorConfig {
+	if c.VoiceLevelsSampleSize == 0 {
+		c.VoiceLevelsSampleSize = defaultVoiceLevelsSampleSize
+	}
+
+	if c.ActivationDuration == 0 {
+		c.ActivationDuration = defaultActivationDuration
+	}
+
+	if c.VoiceActivationThreshold == 0 {
+		c.VoiceActivationThreshold = defaultVoiceActivationThreshold
+	}
+
+	if c.VoiceDeactivationThreshold == 0 {
+		c.VoiceDeactivationThreshold = defaultVoiceDeactivationThreshold
+	}
+
+	return c
+}
+
+func (c MonitorConfig) IsValid() error {
+	if c.VoiceLevelsSampleSize <= 0 {
+		return fmt.Errorf("VoiceLevelsSampleSize should be > 0")
+	}
+
+	if c.ActivationDuration <= 0 {
+		return fmt.Errorf("ActivationDuration should be > 0")
+	}
+
+	if c.VoiceActivationThreshold <= 0 {
+		return fmt.Errorf("VoiceActivationThreshold should be > 0")
+	}
+
+	if c.VoiceDeactivationThreshold <= 0 {
+		return fmt.Errorf("VoiceDeactivationThreshold should be > 0")
+	}
+
+	return nil
+}
+
+func NewMonitor(cfg MonitorConfig, cb VoiceCB) (*Monitor, error) {
+	if err := cfg.IsValid(); err != nil {
+		return nil, fmt.Errorf("invalid config: %s", err)
+	}
+
+	if cb == nil {
+		return nil, fmt.Errorf("voice event callback is required")
+	}
+
+	return &Monitor{
+		cfg:               cfg,
+		voiceLevelsSample: make([]uint8, 0, cfg.VoiceLevelsSampleSize),
+		cb:                cb,
+	}, nil
+}
+
+func getAvg(samples []uint8) uint8 {
+	if len(samples) == 0 {
+		return 0
+	}
+
+	var total float64
+	for _, sample := range samples {
+		total += float64(sample)
+	}
+	return uint8(math.Round(total / float64(len(samples))))
+}
+
+func getStdDev(samples []uint8, avg uint8) uint8 {
+	if len(samples) == 0 {
+		return 0
+	}
+
+	var total float64
+	for _, sample := range samples {
+		total += math.Pow(float64(int(sample)-int(avg)), 2)
+	}
+
+	// Applying Bessel's correction as we are dealing with just a subset of samples.
+	return uint8(math.Round(math.Sqrt(total / float64(len(samples)-1))))
+}
+
+func (m *Monitor) PushAudioLevel(level uint8) {
+	if len(m.voiceLevelsSample) < m.cfg.VoiceLevelsSampleSize {
+		m.voiceLevelsSample = append(m.voiceLevelsSample, level)
+		return
+	}
+
+	m.voiceLevelsSample[m.voiceLevelsSamplePtr] = level
+	if m.voiceLevelsSamplePtr == (m.cfg.VoiceLevelsSampleSize - 1) {
+		m.voiceLevelsSamplePtr = 0
+	} else {
+		m.voiceLevelsSamplePtr++
+	}
+
+	avg := getAvg(m.voiceLevelsSample)
+	dev := getStdDev(m.voiceLevelsSample, avg)
+
+	fmt.Printf("avg: %d\n", avg)
+	fmt.Printf("dev: %d\n", dev)
+
+	var newState bool
+	if !m.voiceState && int(dev) > m.cfg.VoiceActivationThreshold {
+		newState = true
+		m.lastActivationTime = time.Now()
+	} else if m.voiceState && int(dev) < m.cfg.VoiceDeactivationThreshold {
+		newState = false
+	} else {
+		return
+	}
+
+	if newState == m.voiceState || (!newState && time.Since(m.lastActivationTime) < m.cfg.ActivationDuration) {
+		return
+	}
+
+	m.cb(newState)
+	m.voiceState = newState
+}

--- a/service/rtc/vad/vad_test.go
+++ b/service/rtc/vad/vad_test.go
@@ -1,0 +1,167 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package vad
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewMonitor(t *testing.T) {
+	defaultCfg := (MonitorConfig{}).SetDefaults()
+
+	t.Run("invalid config", func(t *testing.T) {
+		m, err := NewMonitor(MonitorConfig{}, func(voice bool) {})
+		require.EqualError(t, err, "invalid config: VoiceLevelsSampleSize should be > 0")
+		require.Nil(t, m)
+	})
+
+	t.Run("missing callback", func(t *testing.T) {
+		m, err := NewMonitor(defaultCfg, nil)
+		require.EqualError(t, err, "voice event callback is required")
+		require.Nil(t, m)
+	})
+
+	t.Run("default config", func(t *testing.T) {
+		m, err := NewMonitor(defaultCfg, func(voice bool) {})
+		require.NoError(t, err)
+		require.NotNil(t, m)
+
+		require.Empty(t, m.voiceLevelsSample)
+		require.Equal(t, defaultCfg, m.cfg)
+	})
+
+	t.Run("custom config", func(t *testing.T) {
+		cfg := MonitorConfig{
+			VoiceLevelsSampleSize:      defaultVoiceLevelsSampleSize * 2,
+			ActivationDuration:         defaultActivationDuration * 2,
+			VoiceActivationThreshold:   defaultVoiceActivationThreshold * 2,
+			VoiceDeactivationThreshold: defaultVoiceDeactivationThreshold * 2,
+		}
+		m, err := NewMonitor(cfg, func(voice bool) {})
+		require.NoError(t, err)
+		require.NotNil(t, m)
+
+		require.Equal(t, cfg, m.cfg)
+	})
+}
+
+func TestGetAvg(t *testing.T) {
+	t.Run("no samples", func(t *testing.T) {
+		require.Equal(t, uint8(0), getAvg(nil))
+		require.Equal(t, uint8(0), getAvg([]uint8{}))
+	})
+
+	t.Run("with samples", func(t *testing.T) {
+		require.Equal(t, uint8(5), getAvg([]uint8{
+			2, 4, 4, 4, 5, 5, 7, 9,
+		}))
+	})
+
+	t.Run("rounded", func(t *testing.T) {
+		require.Equal(t, uint8(3), getAvg([]uint8{
+			1, 2, 3, 4,
+		}))
+
+		require.Equal(t, uint8(3), getAvg([]uint8{
+			1, 2, 3, 4,
+		}))
+
+		require.Equal(t, uint8(1), getAvg([]uint8{
+			9, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		}))
+
+		require.Equal(t, uint8(2), getAvg([]uint8{
+			24, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+		}))
+	})
+}
+
+func TestGetStdDev(t *testing.T) {
+	t.Run("no samples", func(t *testing.T) {
+		require.Equal(t, uint8(0), getStdDev(nil, 0))
+		require.Equal(t, uint8(0), getStdDev([]uint8{}, 0))
+	})
+
+	t.Run("with samples", func(t *testing.T) {
+		samples := []uint8{2, 4, 4, 4, 5, 5, 7, 9}
+		require.Equal(t, uint8(2), getStdDev(samples, getAvg(samples)))
+	})
+
+	t.Run("rounded", func(t *testing.T) {
+		samples := []uint8{2, 4, 9, 4, 5, 5, 7, 9}
+		require.Equal(t, uint8(3), getStdDev(samples, getAvg(samples)))
+	})
+}
+
+func TestPushAudioLevel(t *testing.T) {
+	cfg := MonitorConfig{
+		VoiceLevelsSampleSize:      10,
+		ActivationDuration:         250 * time.Millisecond,
+		VoiceActivationThreshold:   10,
+		VoiceDeactivationThreshold: 5,
+	}
+
+	var voiceOn bool
+	var voiceOff bool
+	cb := func(voice bool) {
+		if voice {
+			voiceOn = true
+		} else {
+			voiceOff = true
+		}
+	}
+
+	m, err := NewMonitor(cfg, cb)
+	require.NoError(t, err)
+	require.NotNil(t, m)
+	require.Empty(t, m.voiceLevelsSample)
+	require.False(t, voiceOn)
+	require.False(t, voiceOff)
+
+	// We fill the voice levels sample.
+	for i := 0; i < cfg.VoiceLevelsSampleSize; i++ {
+		if (i % 2) == 0 {
+			m.PushAudioLevel(55)
+		} else {
+			m.PushAudioLevel(45)
+		}
+	}
+
+	require.Equal(t, uint8(50), getAvg(m.voiceLevelsSample))
+	require.Equal(t, uint8(5), getStdDev(m.voiceLevelsSample, getAvg(m.voiceLevelsSample)))
+	require.False(t, m.voiceState)
+	require.False(t, voiceOn)
+	require.False(t, voiceOff)
+
+	// Pushing some higher levels to trigger voice detection.
+	m.PushAudioLevel(30)
+	m.PushAudioLevel(30)
+	m.PushAudioLevel(30)
+	m.PushAudioLevel(30)
+
+	require.True(t, m.voiceState)
+	require.True(t, voiceOn)
+	require.False(t, voiceOff)
+
+	// Pushing some lower levels to trigger voice detection.
+	m.PushAudioLevel(40)
+	m.PushAudioLevel(40)
+	m.PushAudioLevel(40)
+	m.PushAudioLevel(40)
+	m.PushAudioLevel(40)
+	m.PushAudioLevel(40)
+	m.PushAudioLevel(40)
+	m.PushAudioLevel(40)
+
+	require.True(t, m.voiceState)
+	require.False(t, voiceOff)
+	time.Sleep(cfg.ActivationDuration)
+	m.PushAudioLevel(40)
+
+	require.True(t, voiceOff)
+	require.False(t, m.voiceState)
+}

--- a/service/service.go
+++ b/service/service.go
@@ -202,6 +202,8 @@ func (s *Service) handleRTCMsg(msg rtc.Message) error {
 	switch msg.Type {
 	case rtc.SDPMessage, rtc.ICEMessage:
 		cm.Type = ClientMessageRTC
+	case rtc.VoiceOnMessage, rtc.VoiceOffMessage:
+		cm.Type = ClientMessageVAD
 	default:
 		return fmt.Errorf("unexpected rtc message type: %s", cm.Type)
 	}


### PR DESCRIPTION
#### Summary

It's been a while since I wanted to try this. PR implements server side voice activity detection. This is achieved by reading audio levels coming from clients through the special [`ssrc-audio-level`](https://www.rfc-editor.org/rfc/rfc6464) RTP header extension.

The main benefits of this approach are:

1. It avoids the performance hit needed by the client-side VAD implementation.
2. It should make mobile VAD work without additional changes.
3. The logic feels a bit more robust now. I am using standard deviation of sampled audio levels to figure out voice vs background noise. It may need some further tuning as I couldn't test it on too many systems but it's working decently well so far.

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/285

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49236

