### PR TITLE
[MM-49022] Implement GetVersionInfo client API method

### DIFF
--- a/service/version.go
+++ b/service/version.go
@@ -17,15 +17,15 @@ var (
 	buildDate    string
 )
 
-type versionInfo struct {
+type VersionInfo struct {
 	BuildDate    string `json:"buildDate"`
 	BuildVersion string `json:"buildVersion"`
 	BuildHash    string `json:"buildHash"`
 	GoVersion    string `json:"goVersion"`
 }
 
-func getVersionInfo() versionInfo {
-	return versionInfo{
+func getVersionInfo() VersionInfo {
+	return VersionInfo{
 		BuildDate:    buildDate,
 		BuildVersion: buildVersion,
 		BuildHash:    buildHash,
@@ -33,7 +33,7 @@ func getVersionInfo() versionInfo {
 	}
 }
 
-func (v versionInfo) logFields() []mlog.Field {
+func (v VersionInfo) logFields() []mlog.Field {
 	return []mlog.Field{
 		mlog.String("buildDate", v.BuildDate),
 		mlog.String("buildVersion", v.BuildVersion),

--- a/service/version_test.go
+++ b/service/version_test.go
@@ -36,10 +36,10 @@ func TestGetVersion(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		defer resp.Body.Close()
-		var info versionInfo
+		var info VersionInfo
 		err = json.NewDecoder(resp.Body).Decode(&info)
 		require.NoError(t, err)
-		require.Equal(t, versionInfo{
+		require.Equal(t, VersionInfo{
 			BuildHash:    buildHash,
 			BuildDate:    buildDate,
 			BuildVersion: buildVersion,
@@ -53,10 +53,10 @@ func TestGetVersion(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 		defer resp.Body.Close()
-		var info versionInfo
+		var info VersionInfo
 		err = json.NewDecoder(resp.Body).Decode(&info)
 		require.NoError(t, err)
-		require.Equal(t, versionInfo{
+		require.Equal(t, VersionInfo{
 			GoVersion: goVersion,
 		}, info)
 	})


### PR DESCRIPTION
#### Summary

PR implements a `GetVersionInfo()` client API method to be used by the plugin side to implement minimum version compatibility checks.

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/287

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49022

