### PR TITLE
[MM-49004] Allow UDP listening address to be specified in config

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -23,6 +23,8 @@ security.admin_secret_key = ""
 security.session_cache.expiration_minutes = 1440
 
 [rtc]
+# The IP address used to listen for UDP packets.
+ice_address_udp = ""
 # The UDP port used to route all the media (audio/screen/video tracks).
 ice_port_udp = 8443
 # An optional hostname used to override the default value. By default, the

--- a/docs/env_config.md
+++ b/docs/env_config.md
@@ -9,6 +9,8 @@ RTCD_API_HTTP_TLS_CERTKEY                           String
 RTCD_API_SECURITY_ENABLEADMIN                       True or False
 RTCD_API_SECURITY_ADMINSECRETKEY                    String
 RTCD_API_SECURITY_ALLOWSELFREGISTRATION             True or False
+RTCD_API_SECURITY_SESSIONCACHE_EXPIRATIONMINUTES    Integer
+RTCD_RTC_ICEADDRESSUDP                              String
 RTCD_RTC_ICEPORTUDP                                 Integer
 RTCD_RTC_ICEHOSTOVERRIDE                            String
 RTCD_RTC_ICESERVERS                                 Comma-separated list of 

--- a/service/rtc/config.go
+++ b/service/rtc/config.go
@@ -6,10 +6,13 @@ package rtc
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"strings"
 )
 
 type ServerConfig struct {
+	// ICEAddressUDP specifies the UDP address the RTC service should listen on.
+	ICEAddressUDP string `toml:"ice_address_udp"`
 	// ICEPortUDP specifies the UDP port the RTC service should listen to.
 	ICEPortUDP int `toml:"ice_port_udp"`
 	// ICEHostOverride optionally specifies an IP address (or hostname)
@@ -21,6 +24,10 @@ type ServerConfig struct {
 }
 
 func (c ServerConfig) IsValid() error {
+	if c.ICEAddressUDP != "" && net.ParseIP(c.ICEAddressUDP) == nil {
+		return fmt.Errorf("invalid ICEAddressUDP value: not a valid address")
+	}
+
 	if c.ICEPortUDP < 80 || c.ICEPortUDP > 49151 {
 		return fmt.Errorf("invalid ICEPortUDP value: %d is not in allowed range [80, 49151]", c.ICEPortUDP)
 	}

--- a/service/rtc/config_test.go
+++ b/service/rtc/config_test.go
@@ -16,6 +16,19 @@ func TestServerConfigIsValid(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("invalid ICEAddressUDP", func(t *testing.T) {
+		var cfg ServerConfig
+		cfg.ICEAddressUDP = "not_an_address"
+		err := cfg.IsValid()
+		require.Error(t, err)
+		require.Equal(t, "invalid ICEAddressUDP value: not a valid address", err.Error())
+
+		cfg.ICEAddressUDP = "127.0.0.0.1"
+		err = cfg.IsValid()
+		require.Error(t, err)
+		require.Equal(t, "invalid ICEAddressUDP value: not a valid address", err.Error())
+	})
+
 	t.Run("invalid ICEPortUDP", func(t *testing.T) {
 		var cfg ServerConfig
 		cfg.ICEPortUDP = 22
@@ -44,6 +57,7 @@ func TestServerConfigIsValid(t *testing.T) {
 
 	t.Run("valid", func(t *testing.T) {
 		var cfg ServerConfig
+		cfg.ICEAddressUDP = "127.0.0.1"
 		cfg.ICEPortUDP = 8443
 		cfg.TURNConfig.CredentialsExpirationMinutes = 1440
 		err := cfg.IsValid()

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -113,12 +113,13 @@ func (s *Server) Start() error {
 			},
 		}
 
-		udpConn, err := listenConfig.ListenPacket(context.Background(), "udp4", fmt.Sprintf(":%d", s.cfg.ICEPortUDP))
+		listenAddress := fmt.Sprintf("%s:%d", s.cfg.ICEAddressUDP, s.cfg.ICEPortUDP)
+		udpConn, err := listenConfig.ListenPacket(context.Background(), "udp4", listenAddress)
 		if err != nil {
 			return fmt.Errorf("failed to listen on udp: %w", err)
 		}
 
-		s.log.Info(fmt.Sprintf("rtc: server is listening on udp %d", s.cfg.ICEPortUDP))
+		s.log.Info(fmt.Sprintf("rtc: server is listening on udp %s", listenAddress))
 
 		if err := udpConn.(*net.UDPConn).SetWriteBuffer(udpSocketBufferSize); err != nil {
 			s.log.Warn("rtc: failed to set udp send buffer", mlog.Err(err))


### PR DESCRIPTION
#### Summary

PR adds a new `ice_address_udp` to optionally specify an IP address to use when listening for UDP packets.

#### Related PR

https://github.com/mattermost/mattermost-plugin-calls/pull/293

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49004
