### PR TITLE
[MM-49998] Implement rate litiming on CPU heavy auth operations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/crypto v0.2.0
 	golang.org/x/sys v0.2.0
+	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -737,6 +737,7 @@ golang.org/x/text v0.3.7/go.mod h1:u+2+/6zg+i71rQMx5EYifcz6MCKuco9NR6JIITiCfzQ=
 golang.org/x/time v0.0.0-20180412165947-fbb02b2291d2/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20191024005414-555d28b269f0 h1:/5xXl8Y5W96D+TtHSlonuFqGHIWVuyCkGJLwGh9JJFs=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=

--- a/service/client.go
+++ b/service/client.go
@@ -70,7 +70,7 @@ func NewClient(cfg ClientConfig, opts ...ClientOption) (*Client, error) {
 		MaxConnsPerHost:       100,
 		MaxIdleConns:          100,
 		MaxIdleConnsPerHost:   100,
-		ResponseHeaderTimeout: 10 * time.Second,
+		ResponseHeaderTimeout: 30 * time.Second,
 		IdleConnTimeout:       90 * time.Second,
 		TLSHandshakeTimeout:   1 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,

--- a/service/client.go
+++ b/service/client.go
@@ -55,7 +55,7 @@ func NewClient(cfg ClientConfig, opts ...ClientOption) (*Client, error) {
 	}
 
 	dialFn := (&net.Dialer{
-		Timeout:   5 * time.Second,
+		Timeout:   10 * time.Second,
 		KeepAlive: 30 * time.Second,
 		DualStack: true,
 	}).DialContext

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -635,3 +635,57 @@ func TestClientGetVersionInfo(t *testing.T) {
 		}, info)
 	})
 }
+
+func BenchmarkRegisterClient(b *testing.B) {
+	th := SetupTestHelper(b, nil)
+	defer th.Teardown()
+
+	th.srvc.cfg.API.Security.AllowSelfRegistration = true
+
+	authKey, err := random.NewSecureString(auth.MinKeyLen)
+	require.NoError(b, err)
+
+	b.ResetTimer()
+
+	var i int32
+
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			c, _ := NewClient(ClientConfig{
+				URL: th.apiURL,
+			})
+			defer c.Close()
+			err := c.Register(fmt.Sprintf("client%d", atomic.AddInt32(&i, 1)), authKey)
+			require.NoError(b, err)
+		}
+	})
+}
+
+func TestRegisterClientHerd(t *testing.T) {
+	th := SetupTestHelper(t, nil)
+	defer th.Teardown()
+
+	th.srvc.cfg.API.Security.AllowSelfRegistration = true
+
+	authKey, err := random.NewSecureString(auth.MinKeyLen)
+	require.NoError(t, err)
+
+	n := 100
+	var wg sync.WaitGroup
+	wg.Add(n)
+
+	var i int32
+	for k := 0; k < n; k++ {
+		go func() {
+			defer wg.Done()
+			c, _ := NewClient(ClientConfig{
+				URL: th.apiURL,
+			})
+			defer c.Close()
+			err := c.Register(fmt.Sprintf("client%d", atomic.AddInt32(&i, 1)), authKey)
+			require.NoError(t, err)
+		}()
+	}
+
+	wg.Wait()
+}

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -670,7 +670,8 @@ func TestRegisterClientHerd(t *testing.T) {
 	authKey, err := random.NewSecureString(auth.MinKeyLen)
 	require.NoError(t, err)
 
-	n := 100
+	// NOTE: this value needs to be bumped for any serious benchmarking.
+	n := 10
 	var wg sync.WaitGroup
 	wg.Add(n)
 


### PR DESCRIPTION
#### Summary

PR adds some rate limiting to avoid the number of concurrent CPU heavy auth operations (mostly hashing) that could bring the instance to a halt if many clients connected concurrently.

I tried my best to come up with a sensible value (20 requests per second per CPU available) through some quick benchmarking but it may need more time to properly tune this.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-49998

