### PR TITLE
Fix race condition accessing session

### DIFF
--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -87,6 +87,7 @@ func (c *call) clearScreenState(log mlog.LoggerIFace, sdpOutCh chan<- Message, s
 	}
 
 	for _, s := range c.sessions {
+		s.mut.Lock()
 		if s == c.screenSession {
 			s.clearScreenState()
 			c.screenSession = nil
@@ -98,5 +99,6 @@ func (c *call) clearScreenState(log mlog.LoggerIFace, sdpOutCh chan<- Message, s
 			}
 			s.screenTrackSender = nil
 		}
+		s.mut.Unlock()
 	}
 }

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -414,8 +414,6 @@ func (s *session) InitVAD(log mlog.LoggerIFace, msgCh chan<- Message) error {
 }
 
 func (s *session) clearScreenState() {
-	s.mut.Lock()
-	defer s.mut.Unlock()
 	s.screenStreamID = ""
 	s.outScreenTracks = make(map[string]*webrtc.TrackLocalStaticRTP)
 	s.outScreenAudioTrack = nil


### PR DESCRIPTION
#### Summary

We were locking on the call mutex but failed to lock at the session level when reading/setting the `screenTrackSender`.
