### PR TITLE
Improve local/external IPs mapping when listening on multiple interfaces

### DIFF
--- a/service/rtc/net.go
+++ b/service/rtc/net.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"runtime"
 	"syscall"
+	"time"
 
 	"golang.org/x/sys/unix"
 
@@ -123,4 +124,19 @@ func createUDPConnsForAddr(log mlog.LoggerIFace, listenAddress string) ([]net.Pa
 	}
 
 	return conns, nil
+}
+
+func resolveHost(host string, timeout time.Duration) (string, error) {
+	var ip string
+	r := net.Resolver{}
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	addrs, err := r.LookupIP(ctx, "ip4", host)
+	if err != nil {
+		return ip, fmt.Errorf("failed to resolve host %q: %w", host, err)
+	}
+	if len(addrs) > 0 {
+		ip = addrs[0].String()
+	}
+	return ip, err
 }

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -106,6 +106,8 @@ func (s *Server) Start() error {
 				return fmt.Errorf("failed to resolve UDP address: %w", err)
 			}
 
+			// TODO: consider making this logic concurrent to lower total time taken
+			// in case of multiple interfaces.
 			addr, err := getPublicIP(udpAddr, s.cfg.ICEServers.getSTUN())
 			if err != nil {
 				s.log.Warn("failed to get public IP address for local interface", mlog.String("localAddr", ip), mlog.Err(err))

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -6,6 +6,7 @@ package rtc
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"sync"
 	"time"
 
@@ -29,7 +30,9 @@ type Server struct {
 	groups   map[string]*group
 	sessions map[string]SessionConfig
 
-	udpMux ice.UDPMux
+	udpMux         ice.UDPMux
+	publicAddrsMap map[string]string
+	localIPs       []string
 
 	sendCh    chan Message
 	receiveCh chan Message
@@ -51,14 +54,15 @@ func NewServer(cfg ServerConfig, log mlog.LoggerIFace, metrics Metrics) (*Server
 	}
 
 	s := &Server{
-		cfg:       cfg,
-		log:       log,
-		metrics:   metrics,
-		groups:    map[string]*group{},
-		sessions:  map[string]SessionConfig{},
-		sendCh:    make(chan Message, msgChSize),
-		receiveCh: make(chan Message, msgChSize),
-		bufPool:   &sync.Pool{New: func() interface{} { return make([]byte, receiveMTU) }},
+		cfg:            cfg,
+		log:            log,
+		metrics:        metrics,
+		groups:         map[string]*group{},
+		sessions:       map[string]SessionConfig{},
+		sendCh:         make(chan Message, msgChSize),
+		receiveCh:      make(chan Message, msgChSize),
+		bufPool:        &sync.Pool{New: func() interface{} { return make([]byte, receiveMTU) }},
+		publicAddrsMap: make(map[string]string),
 	}
 
 	return s, nil
@@ -78,33 +82,40 @@ func (s *Server) ReceiveCh() <-chan Message {
 }
 
 func (s *Server) Start() error {
-	if s.cfg.ICEHostOverride == "" && len(s.cfg.ICEServers) > 0 {
-		addr, err := getPublicIP(s.cfg.ICEPortUDP, s.cfg.ICEServers.getSTUN())
-		if err != nil {
-			return fmt.Errorf("failed to get public IP address: %w", err)
-		}
-		s.cfg.ICEHostOverride = addr
-		s.log.Info("got public IP address", mlog.String("addr", addr))
-	}
-
 	var err error
-	var ips []string
 	var muxes []ice.UDPMux
 	if s.cfg.ICEAddressUDP == "" {
 		s.log.Debug("no address specified, going to listen on all supported interfaces")
-		ips, err = getSystemIPs(s.log)
+		s.localIPs, err = getSystemIPs(s.log)
 		if err != nil {
 			return fmt.Errorf("failed to get system IPs: %w", err)
 		}
-		if len(ips) == 0 {
+		if len(s.localIPs) == 0 {
 			return fmt.Errorf("no valid address to listen on was found")
 		}
 	} else {
-		ips = append(ips, s.cfg.ICEAddressUDP)
+		s.localIPs = append(s.localIPs, s.cfg.ICEAddressUDP)
 	}
 
-	for _, ip := range ips {
+	for _, ip := range s.localIPs {
 		listenAddress := fmt.Sprintf("%s:%d", ip, s.cfg.ICEPortUDP)
+
+		if s.cfg.ICEHostOverride == "" && len(s.cfg.ICEServers) > 0 {
+			udpAddr, err := net.ResolveUDPAddr("udp4", listenAddress)
+			if err != nil {
+				return fmt.Errorf("failed to resolve UDP address: %w", err)
+			}
+
+			addr, err := getPublicIP(udpAddr, s.cfg.ICEServers.getSTUN())
+			if err != nil {
+				s.log.Warn("failed to get public IP address for local interface", mlog.String("localAddr", ip), mlog.Err(err))
+			} else {
+				s.log.Info("got public IP address for local interface", mlog.String("localAddr", ip), mlog.String("remoteAddr", addr))
+			}
+
+			s.publicAddrsMap[ip] = addr
+		}
+
 		conns, err := createUDPConnsForAddr(s.log, listenAddress)
 		if err != nil {
 			return fmt.Errorf("failed to create UDP connections: %w", err)

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -189,6 +189,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 	if err != nil {
 		return fmt.Errorf("failed to generate addresses pairs: %w", err)
 	} else if len(pairs) > 0 {
+		s.log.Debug("generated remote/local addrs pairs", mlog.Any("pairs", pairs))
 		sEngine.SetNAT1To1IPs(pairs, webrtc.ICECandidateTypeHost)
 	}
 

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -184,12 +184,12 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 	sEngine := webrtc.SettingEngine{}
 	sEngine.SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)
 	sEngine.SetICEUDPMux(s.udpMux)
-	if s.cfg.ICEHostOverride != "" {
-		hostIP, err := resolveHost(s.cfg.ICEHostOverride, time.Second)
-		if err != nil {
-			return fmt.Errorf("failed to resolve host: %w", err)
-		}
-		sEngine.SetNAT1To1IPs([]string{hostIP}, webrtc.ICECandidateTypeHost)
+
+	pairs, err := generateAddrsPairs(s.localIPs, s.publicAddrsMap, s.cfg.ICEHostOverride)
+	if err != nil {
+		return fmt.Errorf("failed to generate addresses pairs: %w", err)
+	} else if len(pairs) > 0 {
+		sEngine.SetNAT1To1IPs(pairs, webrtc.ICECandidateTypeHost)
 	}
 
 	api := webrtc.NewAPI(

--- a/service/rtc/stun.go
+++ b/service/rtc/stun.go
@@ -12,14 +12,12 @@ import (
 	"github.com/pion/stun"
 )
 
-func getPublicIP(port int, stunURL string) (string, error) {
+func getPublicIP(addr *net.UDPAddr, stunURL string) (string, error) {
 	if stunURL == "" {
 		return "", fmt.Errorf("no STUN server URL was provided")
 	}
 
-	conn, err := net.ListenUDP("udp4", &net.UDPAddr{
-		Port: port,
-	})
+	conn, err := net.ListenUDP("udp4", addr)
 	if err != nil {
 		return "", err
 	}

--- a/service/rtc/utils.go
+++ b/service/rtc/utils.go
@@ -4,29 +4,53 @@
 package rtc
 
 import (
-	"context"
 	"fmt"
-	"net"
 	"time"
 
 	"github.com/mattermost/rtcd/service/random"
 )
 
-func resolveHost(host string, timeout time.Duration) (string, error) {
-	var ip string
-	r := net.Resolver{}
-	ctx, cancel := context.WithTimeout(context.Background(), timeout)
-	defer cancel()
-	addrs, err := r.LookupIP(ctx, "ip4", host)
-	if err != nil {
-		return ip, fmt.Errorf("failed to resolve host %q: %w", host, err)
-	}
-	if len(addrs) > 0 {
-		ip = addrs[0].String()
-	}
-	return ip, err
-}
-
 func genTrackID(trackType, baseID string) string {
 	return trackType + "_" + baseID + "_" + random.NewID()[0:8]
+}
+
+func generateAddrsPairs(localIPs []string, publicAddrsMap map[string]string, hostOverride string) ([]string, error) {
+	var err error
+	var pairs []string
+	var hostOverrideIP string
+
+	if hostOverride != "" {
+		hostOverrideIP, err = resolveHost(hostOverride, time.Second)
+		if err != nil {
+			return pairs, fmt.Errorf("failed to resolve host: %w", err)
+		}
+	}
+
+	usedPublicAddrs := map[string]bool{}
+	for _, localAddr := range localIPs {
+		publicAddr := publicAddrsMap[localAddr]
+
+		// If an override was explicitly provided we enforce that.
+		if hostOverrideIP != "" {
+			publicAddr = hostOverrideIP
+		}
+
+		if publicAddr != "" && !usedPublicAddrs[publicAddr] {
+			// if a public IP has not been used yet we map it to
+			// the first matching local ip.
+			pairs = append(pairs, fmt.Sprintf("%s/%s", publicAddr, localAddr))
+			usedPublicAddrs[publicAddr] = true
+		} else {
+			// if a public IP has been used already we map
+			// any successive matching local ips to themselves.
+			pairs = append(pairs, fmt.Sprintf("%s/%s", localAddr, localAddr))
+		}
+	}
+
+	// If no public address was found/set there's no point in generating pairs.
+	if len(usedPublicAddrs) == 0 {
+		return nil, nil
+	}
+
+	return pairs, nil
 }

--- a/service/rtc/utils_test.go
+++ b/service/rtc/utils_test.go
@@ -1,0 +1,78 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package rtc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateAddrsPairs(t *testing.T) {
+	t.Run("nil/empty inputs", func(t *testing.T) {
+		pairs, err := generateAddrsPairs(nil, nil, "")
+		require.NoError(t, err)
+		require.Empty(t, pairs)
+
+		pairs, err = generateAddrsPairs([]string{}, map[string]string{}, "")
+		require.NoError(t, err)
+		require.Empty(t, pairs)
+	})
+
+	t.Run("no public addresses", func(t *testing.T) {
+		pairs, err := generateAddrsPairs([]string{"127.0.0.1", "10.1.1.1"}, map[string]string{
+			"127.0.0.1": "",
+			"10.1.1.1":  "",
+		}, "")
+		require.NoError(t, err)
+		require.Empty(t, pairs)
+	})
+
+	t.Run("no public addresses with override", func(t *testing.T) {
+		pairs, err := generateAddrsPairs([]string{"127.0.0.1", "10.1.1.1"}, map[string]string{
+			"127.0.0.1": "",
+			"10.1.1.1":  "",
+		}, "1.1.1.1")
+		require.NoError(t, err)
+		require.Equal(t, []string{"1.1.1.1/127.0.0.1", "10.1.1.1/10.1.1.1"}, pairs)
+	})
+
+	t.Run("single public address for multiple local addrs, no override", func(t *testing.T) {
+		pairs, err := generateAddrsPairs([]string{"127.0.0.1", "10.1.1.1"}, map[string]string{
+			"127.0.0.1": "1.1.1.1",
+			"10.1.1.1":  "1.1.1.1",
+		}, "")
+		require.NoError(t, err)
+		require.Equal(t, []string{"1.1.1.1/127.0.0.1", "10.1.1.1/10.1.1.1"}, pairs)
+	})
+
+	t.Run("single local/public address map, no override", func(t *testing.T) {
+		pairs, err := generateAddrsPairs([]string{"127.0.0.1", "10.1.1.1"}, map[string]string{
+			"127.0.0.1": "",
+			"10.1.1.1":  "1.1.1.1",
+		}, "")
+		require.NoError(t, err)
+		require.Equal(t, []string{"127.0.0.1/127.0.0.1", "1.1.1.1/10.1.1.1"}, pairs)
+	})
+
+	t.Run("multiple public addresses, no override", func(t *testing.T) {
+		pairs, err := generateAddrsPairs([]string{"127.0.0.1", "10.1.1.1"}, map[string]string{
+			"127.0.0.1": "1.1.1.1",
+			"10.1.1.1":  "1.1.1.2",
+		}, "")
+		require.NoError(t, err)
+		require.Equal(t, []string{"1.1.1.1/127.0.0.1", "1.1.1.2/10.1.1.1"}, pairs)
+	})
+
+	// This is not a case that would happen in the application because the
+	// override would prevent us from finding public IPs.
+	t.Run("multiple public addresses, with override", func(t *testing.T) {
+		pairs, err := generateAddrsPairs([]string{"127.0.0.1", "10.1.1.1"}, map[string]string{
+			"127.0.0.1": "1.1.1.1",
+			"10.1.1.1":  "1.1.1.2",
+		}, "8.8.8.8")
+		require.NoError(t, err)
+		require.Equal(t, []string{"8.8.8.8/127.0.0.1", "10.1.1.1/10.1.1.1"}, pairs)
+	})
+}


### PR DESCRIPTION
#### Summary

After changes in https://github.com/mattermost/rtcd/pull/92 there was an issue preventing connectivity under certain scenarios as  local (to the rtcd host) candidates could get dropped due to mapping to the same public IP (e.g. ice host override). The solution is to generate a set of `remoteIP/localIP` pairs and pass them down the pion stack.

Right now we are simply mapping the first available interface to the matching public IP and everything else to its own local IP if matching to the same public one. This fixes the connectivity issues I mentioned above as it lets candidates pass deduplication but it's not perfect especially since the first interface is usually the loopback one (e.g. 127.0.0.1). We could add a specific rule to avoid mapping this to a public address but I am a bit wary of changing the existing logic too much if nothing is broken.

Ideally we should surface this kind of configuration to let users deal with more advanced networking scenarios where multiple interfaces are actually used to deliver media to different sets of clients. Some potential improvement for the future as I don't want to complicate things further if there's no real need for it.
