### PR TITLE
Fix CPU leak

### DIFF
--- a/service/rtc/simulcast.go
+++ b/service/rtc/simulcast.go
@@ -118,7 +118,6 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 				rateChangeHandler(rate)
 			case <-s.closeCh:
 				return
-			default:
 			}
 		}
 	}()


### PR DESCRIPTION
#### Summary

The `default` case would cause us to loop continuously causing a huge CPU resource leak.
