### PR TITLE
[MM-50288] Simulcast improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,19 +11,20 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/pion/ice/v2 v2.3.0
 	github.com/pion/interceptor v0.1.12
+	github.com/pion/logging v0.2.2
 	github.com/pion/rtcp v1.2.10
 	github.com/pion/rtp v1.7.13
 	github.com/pion/stun v0.4.0
 	github.com/pion/webrtc/v3 v3.1.55
 	github.com/prometheus/client_golang v1.13.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/crypto v0.6.0
 	golang.org/x/sys v0.5.0
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )
 
-replace github.com/pion/interceptor v0.1.12 => github.com/streamer45/interceptor v0.0.0-20230202152215-57f3ac9e7696
+replace github.com/pion/interceptor v0.1.12 => github.com/streamer45/interceptor v0.0.0-20230411181333-e32ad6baa491
 
 require (
 	github.com/abcum/lcp v0.0.0-20201209214815-7a3f3840be81 // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/pion/datachannel v1.5.5 // indirect
 	github.com/pion/dtls/v2 v2.2.4 // indirect
-	github.com/pion/logging v0.2.2 // indirect
 	github.com/pion/mdns v0.0.7 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
 	github.com/pion/sctp v1.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/streamer45/interceptor v0.0.0-20230202152215-57f3ac9e7696 h1:Uv8BWy1BlS8+2q8gKYTiu/p16+UGq4AyWH0Wb/PsPgY=
-github.com/streamer45/interceptor v0.0.0-20230202152215-57f3ac9e7696/go.mod h1:bDtgAD9dRkBZpWHGKaoKb42FhDHTG2rX8Ii9LRALLVA=
+github.com/streamer45/interceptor v0.0.0-20230411181333-e32ad6baa491 h1:k7+JSEajl6VMnlswWRUL3gIoI4lgU70iFgxvpHgJ3RA=
+github.com/streamer45/interceptor v0.0.0-20230411181333-e32ad6baa491/go.mod h1:+5hNRY+J25Y7GAz/28oYok5yXv9hiKK/64dL5LejL5Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
@@ -473,8 +473,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tidwall/btree v0.4.2/go.mod h1:huei1BkDWJ3/sLXmO+bsCNELL+Bp2Kks9OLyQFkzvA8=

--- a/service/rtc/multi_conn.go
+++ b/service/rtc/multi_conn.go
@@ -45,7 +45,7 @@ func newMultiConn(conns []net.PacketConn) (*multiConn, error) {
 	var mc multiConn
 	mc.conns = conns
 	mc.addr = conns[0].LocalAddr()
-	mc.readResultCh = make(chan readResult)
+	mc.readResultCh = make(chan readResult, len(conns)*2)
 	mc.closeCh = make(chan struct{})
 	mc.bufPool = &sync.Pool{
 		New: func() interface{} {

--- a/service/rtc/rate_test.go
+++ b/service/rtc/rate_test.go
@@ -21,7 +21,10 @@ func TestGetRate(t *testing.T) {
 		rm.PushSample(1000)
 		rm.PushSample(1000)
 
-		require.Equal(t, -1, rm.GetRate())
+		rate, dur := rm.GetRate()
+
+		require.Equal(t, -1, rate)
+		require.Equal(t, time.Duration(0), dur)
 	})
 
 	t.Run("invalid timestamps", func(t *testing.T) {
@@ -38,7 +41,10 @@ func TestGetRate(t *testing.T) {
 
 		rm.PushSample(1000)
 
-		require.Equal(t, -1, rm.GetRate())
+		rate, dur := rm.GetRate()
+
+		require.Equal(t, -1, rate)
+		require.Equal(t, time.Duration(0), dur)
 	})
 
 	t.Run("expected rate", func(t *testing.T) {
@@ -54,27 +60,25 @@ func TestGetRate(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, rm)
 
-		for i := 0; i < 11; i++ {
-			if i > 0 {
-				rm.PushSample(1000)
-			} else {
-				rm.PushSample(0)
-			}
+		for i := 0; i < 22; i++ {
+			rm.PushSample(1000)
 		}
 
-		require.Equal(t, samplingSize, rm.getSamplesDuration())
+		require.Equal(t, samplingSize*2, rm.getSamplesDuration())
 
-		require.Len(t, rm.samples, 11)
-		require.Len(t, rm.timestamps, 11)
-		require.Equal(t, 11, rm.samplesPtr)
+		require.Len(t, rm.samples, 21)
+		require.Len(t, rm.timestamps, 21)
+		require.Equal(t, 22, rm.samplesPtr)
 
-		require.Equal(t, 80000, rm.GetRate())
+		rate, dur := rm.GetRate()
+		require.Equal(t, 80000, rate)
+		require.Equal(t, samplingSize, dur)
 
 		rm, err = NewRateMonitor(time.Second, now)
 		require.NoError(t, err)
 		require.NotNil(t, rm)
 
-		for i := 0; i < 11; i++ {
+		for i := 0; i < 22; i++ {
 			if i%2 == 0 {
 				rm.PushSample(0)
 			} else {
@@ -82,6 +86,8 @@ func TestGetRate(t *testing.T) {
 			}
 		}
 
-		require.Equal(t, 40000, rm.GetRate())
+		rate, dur = rm.GetRate()
+		require.Equal(t, 40000, rate)
+		require.Equal(t, samplingSize, dur)
 	})
 }

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -124,7 +124,7 @@ func (s *session) getRemoteScreenTrack(rid string) *webrtc.TrackRemote {
 	return s.remoteScreenTracks[rid]
 }
 
-func (s *session) getRateMonitor(rid string) *RateMonitor {
+func (s *session) getSourceRate(rid string) int {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
@@ -132,7 +132,16 @@ func (s *session) getRateMonitor(rid string) *RateMonitor {
 		rid = SimulcastLevelDefault
 	}
 
-	return s.screenRateMonitors[rid]
+	rm := s.screenRateMonitors[rid]
+
+	if rm == nil {
+		s.log.Warn("rate monitor should not be nil", mlog.String("sessionID", s.cfg.SessionID))
+		return -1
+	}
+
+	rate, _ := rm.GetRate()
+
+	return rate
 }
 
 func (s *session) getOutScreenTrack(rid string) *webrtc.TrackLocalStaticRTP {

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -308,7 +308,7 @@ func (s *session) addTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) err
 	return nil
 }
 
-// addTrack removes the given track to the peer and starts (re)negotiation.
+// removeTrack removes the given track to the peer and starts (re)negotiation.
 func (s *session) removeTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) error {
 	var sender *webrtc.RTPSender
 

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -426,7 +426,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 				rid = SimulcastLevelDefault
 			}
 
-			rm, err := NewRateMonitor(2*time.Second, nil)
+			rm, err := NewRateMonitor(simulcastRateMonitorSampleSizes[rid], nil)
 			if err != nil {
 				s.log.Error("failed to create rate monitor", mlog.Err(err))
 				return
@@ -493,11 +493,13 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 
 				rm.PushSample(i)
 				if limiter.Allow() {
+					rate, dur := rm.GetRate()
 					s.log.Debug("rate monitor",
 						mlog.String("sessionID", us.cfg.SessionID),
 						mlog.String("RID", rid),
-						mlog.Int("rate", rm.GetRate()),
-						mlog.Float64("time", rm.GetSamplesDuration().Seconds()),
+						mlog.Int("rate", rate),
+						mlog.Float64("duration", dur.Seconds()),
+						mlog.Float64("totalDuration", rm.GetSamplesDuration().Seconds()),
 					)
 				}
 

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -98,7 +98,7 @@ func initInterceptors(m *webrtc.MediaEngine) (*interceptor.Registry, <-chan cc.B
 	}
 
 	// NACK
-	responder, err := nack.NewResponderInterceptor(nack.ResponderSize(nackResponderBufferSize))
+	responder, err := nack.NewResponderInterceptor(nack.ResponderSize(nackResponderBufferSize), nack.DisableCopy())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,13 +117,19 @@ func initInterceptors(m *webrtc.MediaEngine) (*interceptor.Registry, <-chan cc.B
 		return nil, nil, err
 	}
 
-	// Congestion Controller
+	// Congestion Control
+	initialRate := int(float32(getRateForSimulcastLevel(SimulcastLevelLow)) * 0.50)
+	pacer, err := gcc.NewLeakyBucketPacer(initialRate, gcc.PacerDisableCopy())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create pacer: %w", err)
+	}
 	bwEstimatorCh := make(chan cc.BandwidthEstimator, 1)
 	congestionController, err := cc.NewInterceptor(func() (cc.BandwidthEstimator, error) {
 		return gcc.NewSendSideBWE(
-			gcc.SendSideBWEInitialBitrate(int(float32(getRateForSimulcastLevel(SimulcastLevelLow))*0.50)),
+			gcc.SendSideBWEInitialBitrate(initialRate),
 			gcc.SendSideBWEMinBitrate(int(float32(getRateForSimulcastLevel(SimulcastLevelLow))*0.50)),
 			gcc.SendSideBWEMaxBitrate(int(float32(getRateForSimulcastLevel(SimulcastLevelHigh))*1.50)),
+			gcc.SendSideBWEPacer(pacer),
 		)
 	})
 	if err != nil {
@@ -362,22 +368,13 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			}
 
 			for {
-				buf := s.bufPool.Get().([]byte)
-				i, _, readErr := remoteTrack.Read(buf)
+				packet, _, readErr := remoteTrack.ReadRTP()
 				if readErr != nil {
 					if !errors.Is(readErr, io.EOF) {
 						s.log.Error("failed to read RTP packet",
 							mlog.Err(readErr), mlog.String("sessionID", us.cfg.SessionID))
 						s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
 					}
-					return
-				}
-
-				packet := &rtp.Packet{}
-				if err := packet.Unmarshal(buf[:i]); err != nil {
-					s.log.Error("failed to unmarshal RTP packet",
-						mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
-					s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
 					return
 				}
 
@@ -400,7 +397,6 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					isEnabled := us.outVoiceTrackEnabled
 					us.mut.RUnlock()
 					if !isEnabled {
-						s.bufPool.Put(buf)
 						continue
 					}
 				}
@@ -411,8 +407,6 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
 					return
 				}
-
-				s.bufPool.Put(buf)
 			}
 		} else if params, ok := rtpVideoCodecs[trackMimeType]; ok {
 			if screenStreamID != "" && screenStreamID != streamID {
@@ -481,8 +475,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			limiter := rate.NewLimiter(0.25, 1)
 
 			for {
-				buf := s.bufPool.Get().([]byte)
-				i, _, readErr := remoteTrack.Read(buf)
+				packet, _, readErr := remoteTrack.ReadRTP()
 				if readErr != nil {
 					if !errors.Is(readErr, io.EOF) {
 						s.log.Error("failed to read RTP packet",
@@ -492,15 +485,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					return
 				}
 
-				rtp := &rtp.Packet{}
-				if err := rtp.Unmarshal(buf[:i]); err != nil {
-					s.log.Error("failed to unmarshal RTP packet",
-						mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
-					s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
-					return
-				}
-
-				rm.PushSample(i)
+				rm.PushSample(packet.MarshalSize())
 				if limiter.Allow() {
 					rate, dur := rm.GetRate()
 					s.log.Debug("rate monitor",
@@ -512,14 +497,12 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					)
 				}
 
-				if err := outScreenTrack.WriteRTP(rtp); err != nil && !errors.Is(err, io.ErrClosedPipe) {
+				if err := outScreenTrack.WriteRTP(packet); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 					s.log.Error("failed to write RTP packet",
 						mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
 					s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
 					return
 				}
-
-				s.bufPool.Put(buf)
 			}
 		}
 	})

--- a/service/rtc/simulcast.go
+++ b/service/rtc/simulcast.go
@@ -4,7 +4,10 @@
 package rtc
 
 import (
+	"fmt"
 	"time"
+
+	"golang.org/x/time/rate"
 
 	"github.com/pion/interceptor/pkg/cc"
 
@@ -17,7 +20,6 @@ const (
 	SimulcastLevelDefault     = SimulcastLevelLow
 	levelChangeInitialBackoff = 10 * time.Second
 	rateTolerance             = 0.9
-	lossThreshold             = 0.01
 )
 
 var simulcastRates = map[string]int{
@@ -55,8 +57,14 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 	s.bwEstimator = bwEstimator
 	s.mut.Unlock()
 
-	rateCh := make(chan int, 1)
+	// Allowing up to one rate change per second with a burst size of 4.
+	limiter := rate.NewLimiter(1, 4)
+	rateCh := make(chan int, 4)
 	bwEstimator.OnTargetBitrateChange(func(rate int) {
+		if !limiter.Allow() {
+			return
+		}
+
 		select {
 		case rateCh <- rate:
 		default:
@@ -64,15 +72,11 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 		}
 	})
 
-	var lastRate int
 	var backoff time.Duration
 	var lastLevelChangeAt time.Time
 	currLevel := SimulcastLevelDefault
 
 	rateChangeHandler := func(rate int) {
-		rateDiff := (rate - lastRate)
-		lastRate = rate
-
 		stats := bwEstimator.GetStats()
 		lossRate, _ := stats["lossTargetBitrate"].(int)
 		delayRate, _ := stats["delayTargetBitrate"].(int)
@@ -82,53 +86,81 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 			mlog.String("sessionID", s.cfg.SessionID),
 			mlog.Int("delayRate", delayRate),
 			mlog.Int("lossRate", lossRate),
-			mlog.Float64("averageLoss", averageLoss),
+			mlog.String("averageLoss", fmt.Sprintf("%.5f", averageLoss)),
 			mlog.Float64("backoff", backoff.Seconds()),
 			mlog.String("state", state),
-			mlog.Int("rateDiff", rateDiff),
 		)
 
-		// We want to give it some time for the rate estimation to stabilize when
-		// switching up levels. Unless there was some decrease in estimated rate
-		// in which case we want to react as quickly as possible.
-		if time.Since(lastLevelChangeAt) < backoff && (currLevel == SimulcastLevelLow || rateDiff >= 0) {
-			s.log.Debug("skipping bitrate check", mlog.String("sessionID", s.cfg.SessionID))
+		// We want to give it some time for the rate estimation to stabilize
+		// before attempting to upgrade level again.
+		if time.Since(lastLevelChangeAt) < backoff && currLevel == SimulcastLevelLow {
+			s.log.Debug("skipping bitrate check due to backoff", mlog.String("sessionID", s.cfg.SessionID))
 			return
 		}
 
-		// If there's minimal loss we avoid potentially downgrading the level due
-		// to fluctuating rate estimatiob.
-		if averageLoss < lossThreshold && currLevel == SimulcastLevelHigh {
-			s.log.Debug("skipping bitrate check at highest level, no loss", mlog.String("sessionID", s.cfg.SessionID))
-			return
-		}
+		if changed, newRate, newLevel := s.handleSenderBitrateChange(rate, lossRate); changed {
+			// Adding some exponential backoff to avoid switching levels too often
+			// if either client's network conditions fluctuate too often or the client has
+			// not enough bandwidth to handle the higher rate track.
+			if newLevel == SimulcastLevelLow {
+				if backoff == 0 {
+					backoff = levelChangeInitialBackoff
+				} else {
+					backoff = backoff + backoff/2
+				}
+			}
 
-		if changed, newRate, newLevel := s.handleSenderBitrateChange(rate); changed {
-			lastLevelChangeAt = time.Now()
-			currLevel = newLevel
-
-			// Adding some exponential backoff to avoid switching levels like crazy
-			// if either client's bandwidth fluctuates too often or the client has
-			// not enough to handle the higher rate track.
-			if backoff == 0 {
-				backoff = levelChangeInitialBackoff
-			} else {
-				backoff = backoff + backoff/2
+			if newLevel == SimulcastLevelHigh {
+				// On upgrade we update the maximum rate for the estimator to better match the
+				// actual source rate.
+				bwEstimator.SetMaxBitrate(int(float64(newRate) * 1.5))
 			}
 
 			// We update the target bitrate for the estimator to better reflect the
 			// real rate of the source.
-			// TODO: consider tweaking maximum bitrate as well to avoid potentially
-			// plateauing on a higher than real value.
 			bwEstimator.SetTargetBitrate(newRate)
+
+			currLevel = newLevel
+			lastLevelChangeAt = time.Now()
 		}
 	}
 
+	updateMaxSourceRate := func() {
+		screenSession := s.call.getScreenSession()
+		if screenSession == nil || s == screenSession {
+			return
+		}
+
+		if track := screenSession.getRemoteScreenTrack(SimulcastLevelHigh); track == nil {
+			// nothing to do if the sender is not simulcasting.
+			return
+		}
+
+		// We purposely get the highest quality track's rate as it better reflects the
+		// maximum allowed bitrate.
+		sourceRate := screenSession.getSourceRate(SimulcastLevelHigh)
+		if sourceRate <= 0 {
+			s.log.Debug("source rate not available yet", mlog.String("sessionID", s.cfg.SessionID))
+			return
+		}
+
+		s.bwEstimator.SetMaxBitrate(int(float64(sourceRate) * 1.5))
+	}
+
 	go func() {
+		ticker := time.NewTicker(2 * time.Second)
+		defer ticker.Stop()
+
 		for {
 			select {
-			case rate := <-rateCh:
+			case rate, ok := <-rateCh:
+				if !ok {
+					s.log.Info("rateCh was closed, returning", mlog.String("sessionID", s.cfg.SessionID))
+					return
+				}
 				rateChangeHandler(rate)
+			case <-ticker.C:
+				updateMaxSourceRate()
 			case <-s.closeCh:
 				return
 			}
@@ -136,7 +168,7 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 	}()
 }
 
-func (s *session) handleSenderBitrateChange(downRate int) (bool, int, string) {
+func (s *session) handleSenderBitrateChange(downRate int, lossRate int) (bool, int, string) {
 	screenSession := s.call.getScreenSession()
 	if screenSession == nil {
 		return false, 0, ""
@@ -164,15 +196,9 @@ func (s *session) handleSenderBitrateChange(downRate int) (bool, int, string) {
 		return false, 0, ""
 	}
 
-	rm := screenSession.getRateMonitor(currLevel)
-	if rm == nil {
-		s.log.Warn("rate monitor should not be nil")
-		return false, 0, ""
-	}
-
-	currSourceRate, _ := rm.GetRate()
+	currSourceRate := screenSession.getSourceRate(currLevel)
 	if currSourceRate <= 0 {
-		s.log.Warn("current source rate not available yet")
+		s.log.Warn("current source rate not available yet", mlog.String("sessionID", s.cfg.SessionID))
 		return false, 0, ""
 	}
 
@@ -182,18 +208,24 @@ func (s *session) handleSenderBitrateChange(downRate int) (bool, int, string) {
 		return false, 0, ""
 	}
 
+	// If the loss based rate estimation is greater than the source rate we avoid
+	// potentially downgrading the level due to fluctuating delay rate estimation.
+	if currLevel == SimulcastLevelHigh && lossRate > currSourceRate {
+		s.log.Debug("skipping level downgrade, no loss", mlog.String("sessionID", s.cfg.SessionID))
+		return false, 0, ""
+	}
+
 	newTrack := screenSession.getOutScreenTrack(newLevel)
 	if newTrack == nil {
 		// if the desired track is not available we keep the current one
 		return false, 0, ""
 	}
 
-	rm = screenSession.getRateMonitor(newLevel)
-	if rm == nil {
-		s.log.Warn("rate monitor should not be nil")
+	sourceRate := screenSession.getSourceRate(newLevel)
+	if sourceRate <= 0 {
+		s.log.Warn("source rate not available", mlog.String("sessionID", s.cfg.SessionID))
 		return false, 0, ""
 	}
-	sourceRate, _ := rm.GetRate()
 
 	s.log.Debug("switching simulcast level",
 		mlog.String("sessionID", s.cfg.SessionID),


### PR DESCRIPTION
#### Summary

Adding some small improvements to the simulcast logic as I have been testing it more today. Most notable changes are:

- Added an additional check on average loss to determine whether to go ahead with the level change check. Essentially if there's no loss we don't want to downgrade, regardless of the estimated rate. Ideally this shouldn't be needed as the rate from the estimator should already account for that but especially with Firefox the rates are all over the place at times, resulting in a lot of downgrades under optimal network conditions.
- Improved source rate calculation. Also now using different sample sizes based on the simulcast level as samples for higher rate tracks will be much more frequent so we don't need as many for an accurate result.

Plan is to keep testing this for a while under different network conditions after which I'll conduct a load-test. I may send a few more changes if necessary but hopefully this should be the bulk of it.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-50288