### PR TITLE
[MM-51861] Fix race condition with adding tracks on join

### DIFF
--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -15,6 +15,7 @@ type call struct {
 	id            string
 	sessions      map[string]*session
 	screenSession *session
+	metrics       Metrics
 
 	mut sync.RWMutex
 }
@@ -70,12 +71,10 @@ func (c *call) setScreenSession(s *session) bool {
 
 func (c *call) iterSessions(cb func(s *session)) {
 	c.mut.RLock()
+	defer c.mut.RUnlock()
 	for _, session := range c.sessions {
-		c.mut.RUnlock()
 		cb(session)
-		c.mut.RLock()
 	}
-	c.mut.RUnlock()
 }
 
 func (c *call) clearScreenState(screenSession *session) {
@@ -100,5 +99,71 @@ func (c *call) clearScreenState(screenSession *session) {
 			s.screenTrackSender = nil
 		}
 		s.mut.Unlock()
+	}
+}
+
+// handleSessionClose cleans up resources such as senders or receivers for the
+// closing session.
+// NOTE: this is expected to always be called under lock (call.mut).
+func (c *call) handleSessionClose(us *session) {
+	us.mut.RLock()
+	defer us.mut.RUnlock()
+
+	cleanUp := func(sessionID string, sender *webrtc.RTPSender, track webrtc.TrackLocal) {
+		c.metrics.DecRTPTracks(us.cfg.GroupID, us.cfg.CallID, "out", getTrackType(track.Kind()))
+
+		if err := sender.ReplaceTrack(nil); err != nil {
+			us.log.Error("failed to replace track on sender",
+				mlog.String("sessionID", sessionID),
+				mlog.String("trackID", track.ID()))
+		}
+
+		if err := sender.Stop(); err != nil {
+			us.log.Error("failed to stop sender for track",
+				mlog.String("sessionID", sessionID),
+				mlog.String("trackID", track.ID()))
+		}
+	}
+
+	// First we cleanup any track the closing session may have been receiving and stop
+	// the associated senders.
+	for _, sender := range us.rtcConn.GetSenders() {
+		if track := sender.Track(); track != nil {
+			cleanUp(us.cfg.SessionID, sender, track)
+		}
+	}
+
+	// We check whether the closing session was also sending any track
+	// (e.g. voice, screen).
+	outTracks := map[string]bool{}
+	if us.outVoiceTrack != nil {
+		outTracks[us.outVoiceTrack.ID()] = true
+	}
+	if us.outScreenAudioTrack != nil {
+		outTracks[us.outScreenAudioTrack.ID()] = true
+	}
+	for _, track := range us.outScreenTracks {
+		outTracks[track.ID()] = true
+	}
+
+	// Nothing left to do if the closing session wasn't sending anything.
+	if len(outTracks) == 0 {
+		return
+	}
+
+	// We finally go ahead and cleanup any tracks that the closing session may
+	// have been sending to other connected sessions.
+	for _, ss := range c.sessions {
+		if ss.cfg.SessionID == us.cfg.SessionID {
+			continue
+		}
+
+		ss.mut.RLock()
+		for _, sender := range ss.rtcConn.GetSenders() {
+			if track := sender.Track(); track != nil && outTracks[track.ID()] {
+				cleanUp(ss.cfg.SessionID, sender, track)
+			}
+		}
+		ss.mut.RUnlock()
 	}
 }

--- a/service/rtc/metrics.go
+++ b/service/rtc/metrics.go
@@ -7,7 +7,7 @@ type Metrics interface {
 	IncRTCSessions(groupID string, callID string)
 	DecRTCSessions(groupID string, callID string)
 	IncRTCConnState(state string)
-	IncRTPPackets(direction, trackType string)
-	AddRTPPacketBytes(direction, trackType string, value int)
 	IncRTCErrors(groupID string, errType string)
+	IncRTPTracks(groupID string, callID, direction, trackType string)
+	DecRTPTracks(groupID string, callID, direction, trackType string)
 }

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -90,6 +90,7 @@ func (s *Server) addSession(cfg SessionConfig, peerConn *webrtc.PeerConnection, 
 		c = &call{
 			id:       cfg.CallID,
 			sessions: map[string]*session{},
+			metrics:  s.metrics,
 		}
 		g.calls[c.id] = c
 	}
@@ -266,7 +267,7 @@ func (s *session) sendOffer(sdpOutCh chan<- Message) error {
 }
 
 // addTrack adds the given track to the peer and starts negotiation.
-func (s *session) addTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) error {
+func (s *session) addTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) (errRet error) {
 	s.mut.Lock()
 	s.makingOffer = true
 	s.mut.Unlock()
@@ -276,21 +277,41 @@ func (s *session) addTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) err
 		s.mut.Unlock()
 	}()
 
+	s.mut.RLock()
+	for _, sender := range s.rtcConn.GetSenders() {
+		if sender.Track() == track {
+			s.mut.RUnlock()
+			return fmt.Errorf("sender for track already exists")
+		}
+	}
 	sender, err := s.rtcConn.AddTrack(track)
 	if err != nil {
-		return fmt.Errorf("failed to add track: %w", err)
+		s.mut.RUnlock()
+		return fmt.Errorf("failed to add track %s: %w", track.ID(), err)
 	}
+	s.call.metrics.IncRTPTracks(s.cfg.GroupID, s.cfg.CallID, "out", getTrackType(track.Kind()))
+	s.mut.RUnlock()
 
-	if track.Kind() == webrtc.RTPCodecTypeVideo {
-		s.mut.Lock()
-		s.screenTrackSender = sender
-		s.mut.Unlock()
-	}
+	defer func() {
+		if errRet == nil {
+			return
+		}
+
+		s.mut.RLock()
+		if err := sender.ReplaceTrack(nil); err != nil {
+			s.log.Error("failed to replace track",
+				mlog.String("sessionID", s.cfg.SessionID),
+				mlog.String("trackID", track.ID()))
+		} else {
+			s.call.metrics.DecRTPTracks(s.cfg.GroupID, s.cfg.CallID, "out", getTrackType(track.Kind()))
+		}
+		s.mut.RUnlock()
+	}()
 
 	go s.handleSenderRTCP(sender)
 
 	if err := s.sendOffer(sdpOutCh); err != nil {
-		return fmt.Errorf("failed to send offer: %w", err)
+		return fmt.Errorf("failed to send offer for track %s: %w", track.ID(), err)
 	}
 
 	select {
@@ -299,16 +320,24 @@ func (s *session) addTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) err
 			return nil
 		}
 		if err := s.rtcConn.SetRemoteDescription(answer); err != nil {
-			return fmt.Errorf("failed to set remote description: %w", err)
+			return fmt.Errorf("failed to set remote description for track %s: %w", track.ID(), err)
+		}
+		if track.Kind() == webrtc.RTPCodecTypeVideo {
+			s.mut.Lock()
+			s.screenTrackSender = sender
+			s.mut.Unlock()
 		}
 	case <-time.After(signalingTimeout):
 		return fmt.Errorf("timed out signaling")
+	case <-s.closeCh:
+		s.log.Debug("closeCh closed during signaling", mlog.Any("sessionCfg", s.cfg))
+		return nil
 	}
 
 	return nil
 }
 
-// addTrack removes the given track to the peer and starts (re)negotiation.
+// removeTrack removes the given track to the peer and starts (re)negotiation.
 func (s *session) removeTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) error {
 	var sender *webrtc.RTPSender
 
@@ -323,9 +352,13 @@ func (s *session) removeTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) 
 		return fmt.Errorf("failed to find sender for track")
 	}
 
+	s.mut.RLock()
 	if err := s.rtcConn.RemoveTrack(sender); err != nil {
+		s.mut.RUnlock()
 		return fmt.Errorf("failed to remove track: %w", err)
 	}
+	s.call.metrics.DecRTPTracks(s.cfg.GroupID, s.cfg.CallID, "out", getTrackType(track.Kind()))
+	s.mut.RUnlock()
 
 	if err := s.sendOffer(sdpOutCh); err != nil {
 		return fmt.Errorf("failed to send offer: %w", err)
@@ -341,6 +374,9 @@ func (s *session) removeTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) 
 		}
 	case <-time.After(signalingTimeout):
 		return fmt.Errorf("timed out signaling")
+	case <-s.closeCh:
+		s.log.Debug("closeCh closed during signaling", mlog.Any("sessionCfg", s.cfg))
+		return nil
 	}
 
 	return nil

--- a/service/rtc/utils.go
+++ b/service/rtc/utils.go
@@ -8,10 +8,24 @@ import (
 	"time"
 
 	"github.com/mattermost/rtcd/service/random"
+
+	"github.com/pion/webrtc/v3"
 )
 
 func genTrackID(trackType, baseID string) string {
 	return trackType + "_" + baseID + "_" + random.NewID()[0:8]
+}
+
+func getTrackType(kind webrtc.RTPCodecType) string {
+	if kind == webrtc.RTPCodecTypeAudio {
+		return "audio"
+	}
+
+	if kind == webrtc.RTPCodecTypeVideo {
+		return "video"
+	}
+
+	return "unknown"
 }
 
 func generateAddrsPairs(localIPs []string, publicAddrsMap map[string]string, hostOverride string) ([]string, error) {


### PR DESCRIPTION
#### Summary

A race condition on join could cause tracks to be added more than once. This was spotted while I was reviewing some of the Prometheus metrics hence this PR includes those changes as well. In particular:

- Removed `rtp_packets_total` and `rtp_bytes_total`.
  - They caused a [ridiculous number of allocations](https://gist.github.com/streamer45/c6c098e3c0fb5057494054b9dd1642f3) as increment calls were called in a very tight loop.
  - They were not that useful to begin with since ultimately it's more important to track actual network rates.
  - With simulcast enabled, they were not going to be accurate any longer since tracks can be selectively added or removed based on clients' network capacity.
- Added `rtp_tracks_total` to keep count of input/output tracks and their type.
  - This is of particular importance since eventually it's the number one metric to predict performance. Ideally this should be used as the reference counter to load balance calls (tbd, related to https://github.com/mattermost/rtcd/pull/35).

Changes were load-tested.

![image](https://user-images.githubusercontent.com/1832946/229576421-0217bc2a-4905-4eda-9916-f6cc97497aa8.png)

Before merging I'll need to update our reference Grafana dashboard and documentation accordingly.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-51861