### PR TITLE
Performance optimizations

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,14 +17,14 @@ require (
 	github.com/pion/stun v0.4.0
 	github.com/pion/webrtc/v3 v3.1.55
 	github.com/prometheus/client_golang v1.13.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 	github.com/vmihailenco/msgpack/v5 v5.3.5
 	golang.org/x/crypto v0.6.0
 	golang.org/x/sys v0.5.0
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )
 
-replace github.com/pion/interceptor v0.1.12 => github.com/streamer45/interceptor v0.0.0-20230403204744-ad890da73bb8
+replace github.com/pion/interceptor v0.1.12 => github.com/streamer45/interceptor v0.0.0-20230411181333-e32ad6baa491
 
 require (
 	github.com/abcum/lcp v0.0.0-20201209214815-7a3f3840be81 // indirect

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pborman/uuid v1.2.1
 	github.com/pion/ice/v2 v2.3.0
 	github.com/pion/interceptor v0.1.12
+	github.com/pion/logging v0.2.2
 	github.com/pion/rtcp v1.2.10
 	github.com/pion/rtp v1.7.13
 	github.com/pion/stun v0.4.0
@@ -23,7 +24,7 @@ require (
 	golang.org/x/time v0.0.0-20191024005414-555d28b269f0
 )
 
-replace github.com/pion/interceptor v0.1.12 => github.com/streamer45/interceptor v0.0.0-20230202152215-57f3ac9e7696
+replace github.com/pion/interceptor v0.1.12 => github.com/streamer45/interceptor v0.0.0-20230403204744-ad890da73bb8
 
 require (
 	github.com/abcum/lcp v0.0.0-20201209214815-7a3f3840be81 // indirect
@@ -38,7 +39,6 @@ require (
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/pion/datachannel v1.5.5 // indirect
 	github.com/pion/dtls/v2 v2.2.4 // indirect
-	github.com/pion/logging v0.2.2 // indirect
 	github.com/pion/mdns v0.0.7 // indirect
 	github.com/pion/randutil v0.1.0 // indirect
 	github.com/pion/sctp v1.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/streamer45/interceptor v0.0.0-20230202152215-57f3ac9e7696 h1:Uv8BWy1BlS8+2q8gKYTiu/p16+UGq4AyWH0Wb/PsPgY=
-github.com/streamer45/interceptor v0.0.0-20230202152215-57f3ac9e7696/go.mod h1:bDtgAD9dRkBZpWHGKaoKb42FhDHTG2rX8Ii9LRALLVA=
+github.com/streamer45/interceptor v0.0.0-20230403204744-ad890da73bb8 h1:0pLuI3BwYWoxEEZ3KHgYfnokNu0Cms2tjl29NxHaBJk=
+github.com/streamer45/interceptor v0.0.0-20230403204744-ad890da73bb8/go.mod h1:bDtgAD9dRkBZpWHGKaoKb42FhDHTG2rX8Ii9LRALLVA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=

--- a/go.sum
+++ b/go.sum
@@ -457,8 +457,8 @@ github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.8.1/go.mod h1:o0Pch8wJ9BVSWGQMbra6iw0oQ5oktSIBaujf1rJH9Ns=
-github.com/streamer45/interceptor v0.0.0-20230403204744-ad890da73bb8 h1:0pLuI3BwYWoxEEZ3KHgYfnokNu0Cms2tjl29NxHaBJk=
-github.com/streamer45/interceptor v0.0.0-20230403204744-ad890da73bb8/go.mod h1:bDtgAD9dRkBZpWHGKaoKb42FhDHTG2rX8Ii9LRALLVA=
+github.com/streamer45/interceptor v0.0.0-20230411181333-e32ad6baa491 h1:k7+JSEajl6VMnlswWRUL3gIoI4lgU70iFgxvpHgJ3RA=
+github.com/streamer45/interceptor v0.0.0-20230411181333-e32ad6baa491/go.mod h1:+5hNRY+J25Y7GAz/28oYok5yXv9hiKK/64dL5LejL5Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.2.0/go.mod h1:qt09Ya8vawLte6SNmTgCsAVtYtaKzEcn8ATUoHMkEqE=
@@ -473,8 +473,9 @@ github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/tarm/serial v0.0.0-20180830185346-98f6abe2eb07/go.mod h1:kDXzergiv9cbyO7IOYJZWg1U88JhDg3PB6klq9Hg2pA=
 github.com/tidwall/btree v0.4.2/go.mod h1:huei1BkDWJ3/sLXmO+bsCNELL+Bp2Kks9OLyQFkzvA8=

--- a/service/rtc/multi_conn.go
+++ b/service/rtc/multi_conn.go
@@ -45,7 +45,7 @@ func newMultiConn(conns []net.PacketConn) (*multiConn, error) {
 	var mc multiConn
 	mc.conns = conns
 	mc.addr = conns[0].LocalAddr()
-	mc.readResultCh = make(chan readResult)
+	mc.readResultCh = make(chan readResult, len(conns)*2)
 	mc.closeCh = make(chan struct{})
 	mc.bufPool = &sync.Pool{
 		New: func() interface{} {

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -124,7 +124,7 @@ func (s *session) getRemoteScreenTrack(rid string) *webrtc.TrackRemote {
 	return s.remoteScreenTracks[rid]
 }
 
-func (s *session) getRateMonitor(rid string) *RateMonitor {
+func (s *session) getSourceRate(rid string) int {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
@@ -132,7 +132,16 @@ func (s *session) getRateMonitor(rid string) *RateMonitor {
 		rid = SimulcastLevelDefault
 	}
 
-	return s.screenRateMonitors[rid]
+	rm := s.screenRateMonitors[rid]
+
+	if rm == nil {
+		s.log.Warn("rate monitor should not be nil", mlog.String("sessionID", s.cfg.SessionID))
+		return -1
+	}
+
+	rate, _ := rm.GetRate()
+
+	return rate
 }
 
 func (s *session) getOutScreenTrack(rid string) *webrtc.TrackLocalStaticRTP {
@@ -455,4 +464,21 @@ func (s *session) clearScreenState() {
 	s.outScreenAudioTrack = nil
 	s.remoteScreenTracks = make(map[string]*webrtc.TrackRemote)
 	s.screenRateMonitors = make(map[string]*RateMonitor)
+}
+
+func (s *session) getSenderSimulcastLevel() (string, error) {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	sender := s.screenTrackSender
+	if sender == nil {
+		return "", nil
+	}
+
+	currTrack := sender.Track()
+	if currTrack == nil {
+		return "", fmt.Errorf("track should not be nil")
+	}
+
+	return currTrack.RID(), nil
 }

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -465,20 +465,3 @@ func (s *session) clearScreenState() {
 	s.remoteScreenTracks = make(map[string]*webrtc.TrackRemote)
 	s.screenRateMonitors = make(map[string]*RateMonitor)
 }
-
-func (s *session) getSenderSimulcastLevel() (string, error) {
-	s.mut.RLock()
-	defer s.mut.RUnlock()
-
-	sender := s.screenTrackSender
-	if sender == nil {
-		return "", nil
-	}
-
-	currTrack := sender.Track()
-	if currTrack == nil {
-		return "", fmt.Errorf("track should not be nil")
-	}
-
-	return currTrack.RID(), nil
-}

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -98,7 +98,7 @@ func initInterceptors(m *webrtc.MediaEngine) (*interceptor.Registry, <-chan cc.B
 	}
 
 	// NACK
-	responder, err := nack.NewResponderInterceptor(nack.ResponderSize(nackResponderBufferSize))
+	responder, err := nack.NewResponderInterceptor(nack.ResponderSize(nackResponderBufferSize), nack.DisableCopy())
 	if err != nil {
 		return nil, nil, err
 	}
@@ -117,13 +117,19 @@ func initInterceptors(m *webrtc.MediaEngine) (*interceptor.Registry, <-chan cc.B
 		return nil, nil, err
 	}
 
-	// Congestion Controller
+	// Congestion Control
+	initialRate := int(float32(getRateForSimulcastLevel(SimulcastLevelLow)) * 0.50)
+	pacer, err := gcc.NewLeakyBucketPacer(initialRate, gcc.PacerDisableCopy())
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to create pacer: %w", err)
+	}
 	bwEstimatorCh := make(chan cc.BandwidthEstimator, 1)
 	congestionController, err := cc.NewInterceptor(func() (cc.BandwidthEstimator, error) {
 		return gcc.NewSendSideBWE(
-			gcc.SendSideBWEInitialBitrate(int(float32(getRateForSimulcastLevel(SimulcastLevelLow))*0.50)),
+			gcc.SendSideBWEInitialBitrate(initialRate),
 			gcc.SendSideBWEMinBitrate(int(float32(getRateForSimulcastLevel(SimulcastLevelLow))*0.50)),
 			gcc.SendSideBWEMaxBitrate(int(float32(getRateForSimulcastLevel(SimulcastLevelHigh))*1.50)),
+			gcc.SendSideBWEPacer(pacer),
 		)
 	})
 	if err != nil {
@@ -362,22 +368,13 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			}
 
 			for {
-				buf := s.bufPool.Get().([]byte)
-				i, _, readErr := remoteTrack.Read(buf)
+				packet, _, readErr := remoteTrack.ReadRTP()
 				if readErr != nil {
 					if !errors.Is(readErr, io.EOF) {
 						s.log.Error("failed to read RTP packet",
 							mlog.Err(readErr), mlog.String("sessionID", us.cfg.SessionID))
 						s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
 					}
-					return
-				}
-
-				packet := &rtp.Packet{}
-				if err := packet.Unmarshal(buf[:i]); err != nil {
-					s.log.Error("failed to unmarshal RTP packet",
-						mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
-					s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
 					return
 				}
 
@@ -400,19 +397,17 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					isEnabled := us.outVoiceTrackEnabled
 					us.mut.RUnlock()
 					if !isEnabled {
-						s.bufPool.Put(buf)
 						continue
 					}
 				}
 
+				fmt.Printf("write sfu: %p\n", packet.Payload)
 				if err := outAudioTrack.WriteRTP(packet); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 					s.log.Error("failed to write RTP packet",
 						mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
 					s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
 					return
 				}
-
-				s.bufPool.Put(buf)
 			}
 		} else if params, ok := rtpVideoCodecs[trackMimeType]; ok {
 			if screenStreamID != "" && screenStreamID != streamID {
@@ -481,8 +476,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			limiter := rate.NewLimiter(0.25, 1)
 
 			for {
-				buf := s.bufPool.Get().([]byte)
-				i, _, readErr := remoteTrack.Read(buf)
+				packet, _, readErr := remoteTrack.ReadRTP()
 				if readErr != nil {
 					if !errors.Is(readErr, io.EOF) {
 						s.log.Error("failed to read RTP packet",
@@ -492,15 +486,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					return
 				}
 
-				rtp := &rtp.Packet{}
-				if err := rtp.Unmarshal(buf[:i]); err != nil {
-					s.log.Error("failed to unmarshal RTP packet",
-						mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
-					s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
-					return
-				}
-
-				rm.PushSample(i)
+				rm.PushSample(packet.MarshalSize())
 				if limiter.Allow() {
 					rate, dur := rm.GetRate()
 					s.log.Debug("rate monitor",
@@ -512,14 +498,12 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					)
 				}
 
-				if err := outScreenTrack.WriteRTP(rtp); err != nil && !errors.Is(err, io.ErrClosedPipe) {
+				if err := outScreenTrack.WriteRTP(packet); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 					s.log.Error("failed to write RTP packet",
 						mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
 					s.metrics.IncRTCErrors(us.cfg.GroupID, "rtp")
 					return
 				}
-
-				s.bufPool.Put(buf)
 			}
 		}
 	})

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -401,7 +401,6 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					}
 				}
 
-				fmt.Printf("write sfu: %p\n", packet.Payload)
 				if err := outAudioTrack.WriteRTP(packet); err != nil && !errors.Is(err, io.ErrClosedPipe) {
 					s.log.Error("failed to write RTP packet",
 						mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))

--- a/service/rtc/simulcast.go
+++ b/service/rtc/simulcast.go
@@ -59,7 +59,7 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 
 	// Allowing up to one rate change per second with a burst size of 4.
 	limiter := rate.NewLimiter(1, 4)
-	rateCh := make(chan int, 1)
+	rateCh := make(chan int, 4)
 	bwEstimator.OnTargetBitrateChange(func(rate int) {
 		if !limiter.Allow() {
 			return

--- a/service/rtc/simulcast.go
+++ b/service/rtc/simulcast.go
@@ -110,9 +110,11 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 				}
 			}
 
-			// We update the maximum rate for the estimator to better match the
-			// actual source rate.
-			bwEstimator.SetMaxBitrate(int(float64(newRate) * 1.5))
+			if newLevel == SimulcastLevelHigh {
+				// On upgrade we update the maximum rate for the estimator to better match the
+				// actual source rate.
+				bwEstimator.SetMaxBitrate(int(float64(newRate) * 1.5))
+			}
 
 			// We update the target bitrate for the estimator to better reflect the
 			// real rate of the source.
@@ -131,13 +133,9 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 			return
 		}
 
-		currLevel, err := s.getSenderSimulcastLevel()
-		if err != nil {
-			s.log.Error("failed to get sender simulcast level", mlog.String("sessionID", s.cfg.SessionID), mlog.Err(err))
-			return
-		}
-
-		sourceRate := screenSession.getSourceRate(currLevel)
+		// We purposely get the highest quality track's rate as it better reflects the
+		// maximum allowed bitrate.
+		sourceRate := screenSession.getSourceRate(SimulcastLevelHigh)
 		if sourceRate <= 0 {
 			s.log.Debug("source rate not available yet", mlog.String("sessionID", s.cfg.SessionID))
 			return

--- a/service/rtc/simulcast.go
+++ b/service/rtc/simulcast.go
@@ -126,10 +126,13 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 	}
 
 	updateMaxSourceRate := func() {
-		s.mut.RLock()
 		screenSession := s.call.getScreenSession()
-		s.mut.RUnlock()
 		if screenSession == nil || s == screenSession {
+			return
+		}
+
+		if track := screenSession.getRemoteScreenTrack(SimulcastLevelHigh); track == nil {
+			// nothing to do if the sender is not simulcasting.
 			return
 		}
 
@@ -141,9 +144,7 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 			return
 		}
 
-		s.mut.RLock()
 		s.bwEstimator.SetMaxBitrate(int(float64(sourceRate) * 1.5))
-		s.mut.RUnlock()
 	}
 
 	go func() {


### PR DESCRIPTION
#### Summary

The introduction of simulcast support in https://github.com/mattermost/rtcd/pull/90 caused the peak performance at scale, measured as CPU usage, to drop by roughly 50%. This was almost exclusively due to the bandwidth estimation and congestion control logic that was added to support the new functionality.

An extensive series of load-tests was conducted to try and identify any new bottlenecks. This and the related PR (where most performance related changes live) include a number of optimizations aimed at reducing overall CPU load at scale.

Note: currently using a temporary branch to keep the diff clean as this is based on top of both `MM-50288` and `MM-51861`.

#### Load-test info

 The load-test input parameters were the following:

- 25 concurrent calls
- 25 participants/call
- 2 unmuted participants/call
- 25 screen sharing senders (1 per call).

This generated 625 concurrent RTC sessions, 1200 outgoing voice tracks and 600 screen tracks with peak transmission bandwidth of 1.61Gb/s.

#### Results

The proposed changes so far could get back ~20% of the performance penalty of using the new interceptors.
Further work may be required but it may become harder to improve this by much as there's simply a lot more happening than before, and in tight loops (e.g. during RTP packets reception and handling).

![calls_perf_optimizations_april_2023](https://user-images.githubusercontent.com/1832946/229642503-83a8f44f-cf47-4180-8aa2-d07e8d075976.png)

Not applied here, but some potential improvement was seen by playing with the [`GOGC`](https://tip.golang.org/doc/gc-guide) variable which could be used to lower the garbage collector pressure at the expense of higher memory usage. Given the main bottleneck is CPU, it could make sense to consider this as an option for the future. Leaving here for reference some of results of such experiments:

![calls_perf_optimizations_gogc_april_2023](https://user-images.githubusercontent.com/1832946/229641833-6d18c42a-a803-4509-accf-e3f779d231e1.png)

#### Next steps

- Thoroughly test the proposed changes to make sure nothing was altered logic wise, especially with simulcasted tracks.
- Update the performance section in the official documentation (benchmarks) to reflect these results as the vertical scaling capabilities may have noticeably changed (https://mattermost.atlassian.net/browse/MM-51908)

#### Related PR

https://github.com/streamer45/interceptor/pull/2

#### Artifacts

Attaching the following artifacts:

- Baseline CPU and memory (heap) profiles.
- Pre-optimization CPU and memory (heap) profiles.
- Post-optimization CPU and memory (heap) profiles.

[calls_perf_april_2023.zip](https://github.com/mattermost/rtcd/files/11142973/calls_perf_april_2023.zip)


