### PR TITLE
[MM-52650] Bump tracks channel size

### DIFF
--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -22,7 +22,7 @@ import (
 
 const (
 	signalChSize = 20
-	tracksChSize = 10
+	tracksChSize = 100
 )
 
 // session contains all the state necessary to connect a user to a call.


### PR DESCRIPTION
#### Summary

The simplification introduced in https://github.com/mattermost/rtcd/pull/97 meant that on join we are queuing all the tracks before actually adding them. This means that if there are more tracks (e.g. participants that unmuted at least once throughout the call) than the capacity of the channel we'd fail to add some. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-52650