### PR TITLE
[MM-53172] Fix duplicate simulcast sender

### DIFF
--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -106,8 +106,10 @@ func (c *call) clearScreenState(screenSession *session) {
 // closing session.
 // NOTE: this is expected to always be called under lock (call.mut).
 func (c *call) handleSessionClose(us *session) {
-	us.mut.RLock()
-	defer us.mut.RUnlock()
+	us.log.Debug("handleSessionClose", mlog.String("sessionID", us.cfg.SessionID))
+
+	us.mut.Lock()
+	defer us.mut.Unlock()
 
 	cleanUp := func(sessionID string, sender *webrtc.RTPSender, track webrtc.TrackLocal) {
 		c.metrics.DecRTPTracks(us.cfg.GroupID, us.cfg.CallID, "out", getTrackType(track.Kind()))
@@ -158,12 +160,12 @@ func (c *call) handleSessionClose(us *session) {
 			continue
 		}
 
-		ss.mut.RLock()
+		ss.mut.Lock()
 		for _, sender := range ss.rtcConn.GetSenders() {
 			if track := sender.Track(); track != nil && outTracks[track.ID()] {
 				cleanUp(ss.cfg.SessionID, sender, track)
 			}
 		}
-		ss.mut.RUnlock()
+		ss.mut.Unlock()
 	}
 }


### PR DESCRIPTION
#### Summary

PR fixes an issue that could cause duplicate senders to exist in case of simulcast track which would eventually lead to SEGFAULT crash upon screen sharing stopping. The flow causing this issue was roughly the following, assuming two clients (one receiver and one presenter):

1. Both presenter and receiver join the call.
2. Presenter starts screen sharing.
3. Server receives the low quality track first and [sends it to the receiver](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/sfu.go#LL470C1-L470C1).
4. Track is added and [screen sender is set in receiver's session](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/session.go#L336).
5. The bandwidth estimation kicks in and after a couple of seconds the receiver is allowed to get the high track, however this is not available yet.
6. Server receives the high quality and again [sends it to the receiver](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/sfu.go#LL470C1-L470C1) because the level check passes.
7. Track is added and [screen sender is silently overwritten](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/session.go#L336) without actually removing the previous track first (**BUG**).
8. A simulcast level downgrade happens, high track to low track. First the [high track is removed](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/simulcast.go#L217) essentially leaving the sender we set above dangling. Then we attempt to [add the low track](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/simulcast.go#L224) but this operation fails because it was already added and never removed due to the issue above.
9. When the presenter finally stops screen sharing, server will try to remove the current track on the receiver by reading the sender which is still pointing to the high track but that doesn't exist any more (it was removed in the above point). The operation fails of course since there's no sender for the track but [as part of logging the error we try to access the track ID](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/sfu.go#L658) which causes the SEGFAULT since that memory is long gone by then.

Other included changes:

- Added some more logging.
- Slightly reworked the use of some locks to make it less racy.

Since simulcast is currently experimental I am leaning towards skipping a dot release but wait for the upcoming one (`v0.11.0`).

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53172