### PR TITLE
[MM-53182] Fix potential improper rate check in simulcast logic

### DIFF
--- a/service/rtc/simulcast.go
+++ b/service/rtc/simulcast.go
@@ -124,6 +124,11 @@ func (s *session) initBWEstimator(bwEstimator cc.BandwidthEstimator) {
 				bwEstimator.SetTargetBitrate(newRate)
 			}
 
+			// We update the cached rates since the actual source rate could be lower than
+			// the previous ones, causing an improper check above next time the event fires.
+			lastDelayRate = newRate
+			lastLossRate = newRate
+
 			lastLevelChangeAt = time.Now()
 			currLevel = newLevel
 		}


### PR DESCRIPTION
#### Summary

I noticed a very aggressive level downgrade behaviour during the dev meeting today. Essentially the high quality track was getting replaced less than a second after being added under optimal network conditions. 

Turns out the [rate diff check](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/simulcast.go#L110) was causing this since after upgrading [we set the rate to the actual source rate](https://github.com/mattermost/rtcd/blob/de7d3899ad4c6efbd2beeef3e3eb679187dcde58/service/rtc/simulcast.go#L121-L125) but this could actually be lower than the previously estimated rates. To fix this we need to update the cached values with the new rate we are setting.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53182