### PR TITLE
feat: Migrate release pipeline to GHA

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,9 +1,0 @@
----
-
-include:
-  - project: 'mattermost/ci/pipelines'
-    ref: 'master'
-    file: 'default.yml'
-  - project: 'mattermost/ci/pipelines'
-    ref: 'master'
-    file: '${CI_PROJECT_NAME}/gitlab-ci.yml'


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. If this is your first contribution, make sure you've read the Contribution Checklist https://developers.mattermost.com/contribute/getting-started/contribution-checklist/
2. Read our blog post about "Submitting Great PRs" https://developers.mattermost.com/blog/2019-01-24-submitting-great-prs
3. Take a look at other repository specific documentation at https://developers.mattermost.com/contribute
-->

#### Summary
<!--
A description of what this pull request does.
-->
- Remove gitlab-ci configuration in favor of Github Actions
- Release pipeline will exist on our https://github.com/mattermost/delivery-platform repo
- Release pipeline will be triggered upon tag push . Related sensor [here](https://github.com/mattermost/delivery-platform/blob/master/automations/rtcd/release.yaml)

Related PR: https://github.com/mattermost/delivery-platform/pull/6 

#### Ticket Link
<!--
If this pull request addresses a Help Wanted ticket, please link the relevant GitHub issue, e.g.

  Fixes https://github.com/mattermost/mattermost-server/issues/XXXXX

Otherwise, link the JIRA ticket.
-->
https://mattermost.atlassian.net/browse/CLD-3881
