### PR TITLE
[MM-53483] Tune authentication concurrency to avoid excessive CPU usage

### DIFF
--- a/service/auth.go
+++ b/service/auth.go
@@ -52,7 +52,7 @@ func (s *Service) basicAuthHandler(_ http.ResponseWriter, r *http.Request) (stri
 	}
 
 	if err := s.auth.Authenticate(clientID, authKey); err != nil {
-		s.log.Error("authentication failed", mlog.Err(err))
+		s.log.Error("authentication failed", mlog.Err(err), mlog.String("clientID", clientID))
 		return "", http.StatusUnauthorized, errors.New("authentication failed")
 	}
 

--- a/service/auth/service.go
+++ b/service/auth/service.go
@@ -16,9 +16,9 @@ import (
 )
 
 const (
-	MinKeyLen                        = 32
-	authTimeout                      = 10 * time.Second
-	authRequestsPerSecond rate.Limit = 20
+	MinKeyLen                              = 32
+	authTimeout                            = 10 * time.Second
+	authRequestsPerSecondPerCPU rate.Limit = 12 // MM-53483
 )
 
 type Service struct {
@@ -37,7 +37,7 @@ func NewService(store store.Store, sessionCache *SessionCache) (*Service, error)
 	return &Service{
 		sessionCache: sessionCache,
 		store:        store,
-		limiter:      rate.NewLimiter(authRequestsPerSecond*rate.Limit(runtime.NumCPU()), 1),
+		limiter:      rate.NewLimiter(authRequestsPerSecondPerCPU*rate.Limit(runtime.NumCPU()), 1),
 	}, nil
 }
 

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -157,20 +157,20 @@ func (s *Server) Stop() error {
 		<-drainCh
 	}
 
+	close(s.receiveCh)
+	close(s.sendCh)
+
+	if s.tcpMux != nil {
+		if err := s.tcpMux.Close(); err != nil {
+			return fmt.Errorf("failed to close tcp mux: %w", err)
+		}
+	}
+
 	if s.udpMux != nil {
 		if err := s.udpMux.Close(); err != nil {
 			return fmt.Errorf("failed to close udp mux: %w", err)
 		}
 	}
-
-	if s.tcpMux != nil {
-		if err := s.tcpMux.Close(); err != nil {
-			return fmt.Errorf("failed to close udp mux: %w", err)
-		}
-	}
-
-	close(s.receiveCh)
-	close(s.sendCh)
 
 	s.log.Info("rtc: server was shutdown")
 


### PR DESCRIPTION
#### Summary

Full context of the on-going investigation is on the attached JIRA ticket. As things stand I don't think there's an issue on the application side. That said, I think the value we used to limit the concurrency of key hashing operations was a bit overly optimistic. I conducted a batch of bechmarks and tuned the value down so that at most (on average) it will consume around 80% of CPU time.

I also looked into whether we could make the hashing operation quicker but it doesn't seem a particularly clever idea to mess with the `bcrypt` cost (see https://wildlyinaccurate.com/bcrypt-choosing-a-work-factor/).

At the end of the day the problem is that this service is not really designed to be hit by hundreds of registration requests at once, something that happens on Cloud for two reasons:

1. We don't use a persistent storage volume so at every upgrade (pod restart) we have all the connected clients attempt to re-register at once. We try to spread them as best as we can through the use of some [random jitter](https://github.com/mattermost/mattermost-plugin-calls/blob/775c33e54b1ef55df3012a9f334fef09f4d304ff/server/rtcd.go#L436-L438) but there's only so much we can do.
2. Our deployment is underscaled. We shouldn't really have hundreds of clients (MM installations) connecting to a 4 cores `rtcd` instance. We get away with this because calls are extremely rare on Cloud but it would unreasonable in any realistic circumstance of moderate usage.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53483