### PR TITLE
[MM-53511] Properly remove screen sharing tracks if sender suddenly drops

### DIFF
--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -266,7 +266,9 @@ func (s *Server) msgReader() {
 				s.log.Error("screen session should not be set")
 			}
 		case ScreenOffMessage:
-			call.clearScreenState(session)
+			if err := call.clearScreenState(session); err != nil {
+				s.log.Error("failed to clear screen state", mlog.Err(err))
+			}
 		case MuteMessage, UnmuteMessage:
 			session.mut.RLock()
 			track := session.outVoiceTrack

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -662,7 +662,11 @@ func (s *Server) handleTracks(call *call, us *session) {
 			} else if ctx.action == trackActionRemove {
 				if err := us.removeTrack(s.receiveCh, ctx.track); err != nil {
 					s.metrics.IncRTCErrors(us.cfg.GroupID, "track")
-					s.log.Error("failed to remove track", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID), mlog.String("trackID", ctx.track.ID()))
+					var trackID string
+					if ctx.track != nil {
+						trackID = ctx.track.ID()
+					}
+					s.log.Error("failed to remove track", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID), mlog.String("trackID", trackID))
 					continue
 				}
 			} else {

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -589,9 +589,6 @@ func (s *Server) CloseSession(sessionID string) error {
 
 	call.handleSessionClose(us)
 
-	if us == call.screenSession {
-		call.screenSession = nil
-	}
 	delete(call.sessions, cfg.SessionID)
 	if len(call.sessions) == 0 {
 		group.mut.Lock()


### PR DESCRIPTION
#### Summary

In https://github.com/mattermost/rtcd/pull/107 I had a good thought of returning an error if a `screenTrackSender` was getting overwritten. The only problem was that it didn't prevent a panic from happening next time we tried to remove a `nil` track.

PR makes sure of two things:

1. (panic fix) If removing a track fails, we check whether that's because it was a `nil` track and we only extract its ID if that's not the case.
2. (functionality fix) When a session suddenly drops without sending the expected events (e.g. `ScreenOffMessage`) we are now properly removing the track from the receivers who are left and clearing `screenTrackSender` so that next time someone attempts to share it won't be failing.
 
#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53511
