### PR TITLE
Improve logging

### DIFF
--- a/service/rtc/logger.go
+++ b/service/rtc/logger.go
@@ -5,10 +5,32 @@ package rtc
 
 import (
 	"fmt"
+	"runtime"
+	"strings"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/pion/logging"
 )
+
+const pionPkgPrefix = "github.com/pion/"
+
+func getLogOrigin() string {
+	pc, file, line, ok := runtime.Caller(2)
+	if !ok {
+		return ""
+	}
+
+	f := runtime.FuncForPC(pc)
+	if f == nil {
+		return ""
+	}
+
+	if idx := strings.Index(file, pionPkgPrefix); idx > 0 {
+		file = file[idx+len(pionPkgPrefix):]
+	}
+
+	return fmt.Sprintf("%s %s:%d", strings.TrimPrefix(f.Name(), pionPkgPrefix), file, line)
+}
 
 type pionLogger struct {
 	log mlog.LoggerIFace
@@ -20,42 +42,46 @@ func newPionLeveledLogger(log mlog.LoggerIFace) logging.LeveledLogger {
 	}
 }
 
+func (s *Server) NewLogger(_ string) logging.LeveledLogger {
+	return newPionLeveledLogger(s.log)
+}
+
 func (log *pionLogger) Trace(msg string) {
-	log.log.Trace(msg)
+	log.log.Trace(msg, mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Tracef(format string, args ...interface{}) {
-	log.log.Trace(fmt.Sprintf(format, args...))
+	log.log.Trace(fmt.Sprintf(format, args...), mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Debug(msg string) {
-	log.log.Trace(msg)
+	log.log.Trace(msg, mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Debugf(format string, args ...interface{}) {
-	log.log.Trace(fmt.Sprintf(format, args...))
+	log.log.Trace(fmt.Sprintf(format, args...), mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Info(msg string) {
-	log.log.Info(msg)
+	log.log.Info(msg, mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Infof(format string, args ...interface{}) {
-	log.log.Info(fmt.Sprintf(format, args...))
+	log.log.Info(fmt.Sprintf(format, args...), mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Warn(msg string) {
-	log.log.Warn(msg)
+	log.log.Warn(msg, mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Warnf(format string, args ...interface{}) {
-	log.log.Warn(fmt.Sprintf(format, args...))
+	log.log.Warn(fmt.Sprintf(format, args...), mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Error(msg string) {
-	log.log.Error(msg)
+	log.log.Error(msg, mlog.String("origin", getLogOrigin()))
 }
 
 func (log *pionLogger) Errorf(format string, args ...interface{}) {
-	log.log.Error(fmt.Sprintf(format, args...))
+	log.log.Error(fmt.Sprintf(format, args...), mlog.String("origin", getLogOrigin()))
 }

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -63,7 +63,9 @@ const (
 )
 
 func (s *Server) initSettingEngine() (webrtc.SettingEngine, error) {
-	sEngine := webrtc.SettingEngine{}
+	sEngine := webrtc.SettingEngine{
+		LoggerFactory: s,
+	}
 	sEngine.SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)
 	networkTypes := []webrtc.NetworkType{
 		webrtc.NetworkTypeUDP4,


### PR DESCRIPTION
#### Summary

We were missing potentially useful warnings from our logs that would ease debugging issues. Given Pion has an easy way to pass a proper logger we wrap our existing one so that everything can get printed out nicely.

#### Sample output:

```
info  [2023-07-25 16:09:31.866 -06:00] peer connection state changed: connected      caller="rtc/logger.go:70" origin="webrtc/v3.(*PeerConnection).onConnectionStateChange webrtc/peerconnection.go:495"
warn  [2023-07-25 16:09:31.867 -06:00] test warning                                  caller="rtc/logger.go:78" origin="webrtc/v3.(*PeerConnection).undeclaredMediaProcessor webrtc/peerconnection.go:1627"
error [2023-07-25 16:09:31.867 -06:00] test error                                    caller="rtc/logger.go:86" origin="webrtc/v3.(*PeerConnection).undeclaredMediaProcessor webrtc/peerconnection.go:1628"
```