### PR TITLE
[MM-53807] Explicitly stop receiver on exit

### DIFF
--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -331,6 +331,17 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 				mlog.Int("ssrc", int(remoteTrack.SSRC())),
 				mlog.String("rid", remoteTrack.RID()),
 				mlog.String("sessionID", us.cfg.SessionID))
+
+			if err := receiver.Stop(); err != nil {
+				s.log.Error("failed to stop receiver",
+					mlog.Err(err),
+					mlog.String("streamID", streamID),
+					mlog.String("remoteTrackID", remoteTrack.ID()),
+					mlog.Int("ssrc", int(remoteTrack.SSRC())),
+					mlog.String("rid", remoteTrack.RID()),
+					mlog.String("sessionID", us.cfg.SessionID))
+			}
+
 			s.metrics.DecRTPTracks(us.cfg.GroupID, us.cfg.CallID, "in", getTrackType(remoteTrack.Kind()))
 		}()
 


### PR DESCRIPTION
#### Summary

I wasn't able to reproduce this so not sure this addition will have any effect but until we get more logs (https://github.com/mattermost/rtcd/pull/116) it's hard to say what's going on. 

There's no clear indication that we are leaking anything on our side assuming that closing the peer connection would be enough to release all its resources.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-53807
