### PR TITLE
Don't decrease counter for internal/unused tracks

### DIFF
--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -124,7 +124,15 @@ func (c *call) handleSessionClose(us *session) {
 	defer us.mut.Unlock()
 
 	cleanUp := func(sessionID string, sender *webrtc.RTPSender, track webrtc.TrackLocal) {
-		c.metrics.DecRTPTracks(us.cfg.GroupID, us.cfg.CallID, "out", getTrackType(track.Kind()))
+		if isValidTrackID(track.ID()) {
+			c.metrics.DecRTPTracks(us.cfg.GroupID, us.cfg.CallID, "out", getTrackType(track.Kind()))
+		} else {
+			us.log.Warn("invalid track ID",
+				mlog.String("sessionID", sessionID),
+				mlog.String("trackID", track.ID()),
+				mlog.Any("trackKind", track.Kind()))
+		}
+
 		if err := sender.ReplaceTrack(nil); err != nil {
 			us.log.Error("failed to replace track on sender",
 				mlog.String("sessionID", sessionID),

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -355,10 +355,10 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 		go us.handleReceiverRTCP(receiver, remoteTrack.RID())
 
 		if trackMimeType == rtpAudioCodec.MimeType {
-			trackType := "voice"
+			trackType := trackTypeVoice
 			if streamID == screenStreamID {
 				s.log.Debug("received screen sharing audio track", mlog.String("sessionID", us.cfg.SessionID))
-				trackType = "screen-audio"
+				trackType = trackTypeScreenAudio
 			}
 
 			outAudioTrack, err := webrtc.NewTrackLocalStaticRTP(rtpAudioCodec, genTrackID(trackType, us.cfg.SessionID), random.NewID())
@@ -368,7 +368,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			}
 
 			us.mut.Lock()
-			if trackType == "voice" {
+			if trackType == trackTypeVoice {
 				us.outVoiceTrack = outAudioTrack
 				us.outVoiceTrackEnabled = true
 			} else {
@@ -435,7 +435,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					}
 				}
 
-				if trackType == "voice" {
+				if trackType == trackTypeVoice {
 					us.mut.RLock()
 					isEnabled := us.outVoiceTrackEnabled
 					us.mut.RUnlock()
@@ -460,7 +460,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 
 			s.log.Debug("received screen sharing stream", mlog.String("streamID", streamID), mlog.String("sessionID", us.cfg.SessionID))
 
-			outScreenTrack, err := webrtc.NewTrackLocalStaticRTP(params.RTPCodecCapability, genTrackID("screen", us.cfg.SessionID), random.NewID(), webrtc.WithRTPStreamID(remoteTrack.RID()))
+			outScreenTrack, err := webrtc.NewTrackLocalStaticRTP(params.RTPCodecCapability, genTrackID(trackTypeScreen, us.cfg.SessionID), random.NewID(), webrtc.WithRTPStreamID(remoteTrack.RID()))
 			if err != nil {
 				s.log.Error("failed to create local track",
 					mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))

--- a/service/rtc/utils.go
+++ b/service/rtc/utils.go
@@ -14,8 +14,31 @@ import (
 	"github.com/pion/webrtc/v3"
 )
 
-func genTrackID(trackType, baseID string) string {
-	return trackType + "_" + baseID + "_" + random.NewID()[0:8]
+type trackType string
+
+const (
+	trackTypeVoice       trackType = "voice"
+	trackTypeScreen                = "screen"
+	trackTypeScreenAudio           = "screen-audio"
+)
+
+var trackTypes = map[string]trackType{
+	"voice":        trackTypeVoice,
+	"screen":       trackTypeScreen,
+	"screen-audio": trackTypeScreenAudio,
+}
+
+func genTrackID(tt trackType, baseID string) string {
+	return string(tt) + "_" + baseID + "_" + random.NewID()[0:8]
+}
+
+func isValidTrackID(trackID string) bool {
+	fields := strings.Split(trackID, "_")
+	if len(fields) != 3 {
+		return false
+	}
+
+	return trackTypes[fields[0]] != ""
 }
 
 func getTrackType(kind webrtc.RTPCodecType) string {

--- a/service/rtc/utils_test.go
+++ b/service/rtc/utils_test.go
@@ -104,3 +104,53 @@ func TestGenerateAddrsPairs(t *testing.T) {
 		require.Equal(t, []string{"127.0.0.1/127.0.0.1", "8.8.8.8/10.1.1.1"}, pairs)
 	})
 }
+
+func TestIsValidTrackID(t *testing.T) {
+	tcs := []struct {
+		name   string
+		input  string
+		result bool
+	}{
+		{
+			name:   "empty",
+			input:  "",
+			result: false,
+		},
+		{
+			name:   "not enough fields",
+			input:  "screen_id",
+			result: false,
+		},
+		{
+			name:   "too many fields",
+			input:  "screen_id_id_id",
+			result: false,
+		},
+		{
+			name:   "invalid track type",
+			input:  "video_id_id",
+			result: false,
+		},
+		{
+			name:   "valid screen",
+			input:  "screen_id_id",
+			result: true,
+		},
+		{
+			name:   "valid voice",
+			input:  "voice_id_id",
+			result: true,
+		},
+		{
+			name:   "valid screen audio",
+			input:  "screen-audio_id_id",
+			result: true,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.result, isValidTrackID(tc.input))
+		})
+	}
+}


### PR DESCRIPTION
#### Summary

Looking at metrics on Community I spotted something a little disturbing. Our counter for output video (screen) tracks went negative. 

![image](https://github.com/mattermost/rtcd/assets/1832946/026f04e8-9f71-4ed3-adb7-dc24e1adba7b)

Inspecting the logs revealed an unusual track being removed when the session closed:

![image](https://github.com/mattermost/rtcd/assets/1832946/50fc3cc7-f124-4a42-9c2f-222dc9b60fe8)

My theory so far is that the track is created internally by `pion` as a result of the client negotiating a `sendrecv` transceiver.  To avoid this sort of issues, before decreasing the counter we are adding a track ID validation function that will only match tracks explicitly created by us.
