### PR TITLE
[MM-54445] Remove CallID label from metrics

### DIFF
--- a/service/perf/metrics.go
+++ b/service/perf/metrics.go
@@ -48,7 +48,7 @@ func NewMetrics(namespace string, registry *prometheus.Registry) *Metrics {
 			Name:      "rtp_tracks_total",
 			Help:      "Total number of active RTP tracks",
 		},
-		[]string{"groupID", "callID", "direction", "type"},
+		[]string{"groupID", "direction", "type"},
 	)
 	m.registry.MustRegister(m.RTPTracks)
 
@@ -59,7 +59,7 @@ func NewMetrics(namespace string, registry *prometheus.Registry) *Metrics {
 			Name:      "sessions_total",
 			Help:      "Total number of active RTC sessions",
 		},
-		[]string{"groupID", "callID"},
+		[]string{"groupID"},
 	)
 	m.registry.MustRegister(m.RTCSessions)
 
@@ -110,12 +110,12 @@ func NewMetrics(namespace string, registry *prometheus.Registry) *Metrics {
 	return &m
 }
 
-func (m *Metrics) IncRTCSessions(groupID string, callID string) {
-	m.RTCSessions.With(prometheus.Labels{"groupID": groupID, "callID": callID}).Inc()
+func (m *Metrics) IncRTCSessions(groupID string) {
+	m.RTCSessions.With(prometheus.Labels{"groupID": groupID}).Inc()
 }
 
-func (m *Metrics) DecRTCSessions(groupID string, callID string) {
-	m.RTCSessions.With(prometheus.Labels{"groupID": groupID, "callID": callID}).Dec()
+func (m *Metrics) DecRTCSessions(groupID string) {
+	m.RTCSessions.With(prometheus.Labels{"groupID": groupID}).Dec()
 }
 
 func (m *Metrics) IncRTCConnState(state string) {
@@ -126,12 +126,12 @@ func (m *Metrics) IncRTCErrors(groupID string, errType string) {
 	m.RTCErrors.With(prometheus.Labels{"type": errType, "groupID": groupID}).Inc()
 }
 
-func (m *Metrics) IncRTPTracks(groupID, callID, direction, trackType string) {
-	m.RTPTracks.With(prometheus.Labels{"groupID": groupID, "callID": callID, "direction": direction, "type": trackType}).Inc()
+func (m *Metrics) IncRTPTracks(groupID, direction, trackType string) {
+	m.RTPTracks.With(prometheus.Labels{"groupID": groupID, "direction": direction, "type": trackType}).Inc()
 }
 
-func (m *Metrics) DecRTPTracks(groupID, callID, direction, trackType string) {
-	m.RTPTracks.With(prometheus.Labels{"groupID": groupID, "callID": callID, "direction": direction, "type": trackType}).Dec()
+func (m *Metrics) DecRTPTracks(groupID, direction, trackType string) {
+	m.RTPTracks.With(prometheus.Labels{"groupID": groupID, "direction": direction, "type": trackType}).Dec()
 }
 
 func (m *Metrics) IncWSConnections(clientID string) {

--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -125,7 +125,7 @@ func (c *call) handleSessionClose(us *session) {
 
 	cleanUp := func(sessionID string, sender *webrtc.RTPSender, track webrtc.TrackLocal) {
 		if isValidTrackID(track.ID()) {
-			c.metrics.DecRTPTracks(us.cfg.GroupID, us.cfg.CallID, "out", getTrackType(track.Kind()))
+			c.metrics.DecRTPTracks(us.cfg.GroupID, "out", getTrackType(track.Kind()))
 		} else {
 			us.log.Warn("invalid track ID",
 				mlog.String("sessionID", sessionID),

--- a/service/rtc/metrics.go
+++ b/service/rtc/metrics.go
@@ -4,10 +4,10 @@
 package rtc
 
 type Metrics interface {
-	IncRTCSessions(groupID string, callID string)
-	DecRTCSessions(groupID string, callID string)
+	IncRTCSessions(groupID string)
+	DecRTCSessions(groupID string)
 	IncRTCConnState(state string)
 	IncRTCErrors(groupID string, errType string)
-	IncRTPTracks(groupID string, callID, direction, trackType string)
-	DecRTPTracks(groupID string, callID, direction, trackType string)
+	IncRTPTracks(groupID string, direction, trackType string)
+	DecRTPTracks(groupID string, direction, trackType string)
 }

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -311,7 +311,7 @@ func (s *session) addTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) (er
 		s.mut.Unlock()
 		return fmt.Errorf("failed to add track %s: %w", track.ID(), err)
 	}
-	s.call.metrics.IncRTPTracks(s.cfg.GroupID, s.cfg.CallID, "out", getTrackType(track.Kind()))
+	s.call.metrics.IncRTPTracks(s.cfg.GroupID, "out", getTrackType(track.Kind()))
 	s.mut.Unlock()
 
 	defer func() {
@@ -325,7 +325,7 @@ func (s *session) addTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) (er
 				mlog.String("sessionID", s.cfg.SessionID),
 				mlog.String("trackID", track.ID()))
 		} else {
-			s.call.metrics.DecRTPTracks(s.cfg.GroupID, s.cfg.CallID, "out", getTrackType(track.Kind()))
+			s.call.metrics.DecRTPTracks(s.cfg.GroupID, "out", getTrackType(track.Kind()))
 		}
 		s.mut.Unlock()
 	}()
@@ -387,7 +387,7 @@ func (s *session) removeTrack(sdpOutCh chan<- Message, track webrtc.TrackLocal) 
 		s.mut.Unlock()
 		return fmt.Errorf("failed to remove track: %w", err)
 	}
-	s.call.metrics.DecRTPTracks(s.cfg.GroupID, s.cfg.CallID, "out", getTrackType(track.Kind()))
+	s.call.metrics.DecRTPTracks(s.cfg.GroupID, "out", getTrackType(track.Kind()))
 
 	if s.screenTrackSender == sender {
 		s.screenTrackSender = nil

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -178,7 +178,7 @@ func initInterceptors(m *webrtc.MediaEngine) (*interceptor.Registry, <-chan cc.B
 }
 
 func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
-	s.metrics.IncRTCSessions(cfg.GroupID, cfg.CallID)
+	s.metrics.IncRTCSessions(cfg.GroupID)
 
 	iceServers := make([]webrtc.ICEServer, 0, len(s.cfg.ICEServers))
 	for _, iceCfg := range s.cfg.ICEServers {
@@ -325,7 +325,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			mlog.String("sessionID", us.cfg.SessionID),
 		)
 
-		s.metrics.IncRTPTracks(us.cfg.GroupID, us.cfg.CallID, "in", getTrackType(remoteTrack.Kind()))
+		s.metrics.IncRTPTracks(us.cfg.GroupID, "in", getTrackType(remoteTrack.Kind()))
 		defer func() {
 			s.log.Debug("exiting track handler",
 				mlog.String("streamID", streamID),
@@ -344,7 +344,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					mlog.String("sessionID", us.cfg.SessionID))
 			}
 
-			s.metrics.DecRTPTracks(us.cfg.GroupID, us.cfg.CallID, "in", getTrackType(remoteTrack.Kind()))
+			s.metrics.DecRTPTracks(us.cfg.GroupID, "in", getTrackType(remoteTrack.Kind()))
 		}()
 
 		var screenStreamID string
@@ -597,7 +597,7 @@ func (s *Server) CloseSession(sessionID string) error {
 		return nil
 	}
 
-	s.metrics.DecRTCSessions(cfg.GroupID, cfg.CallID)
+	s.metrics.DecRTCSessions(cfg.GroupID)
 
 	group := s.getGroup(cfg.GroupID)
 	if group == nil {


### PR DESCRIPTION
#### Summary

I rarely had to group by `callID` in practice and it was also causing lots of redundant metrics potentially affecting performance on installations making use of calls in many channels. I think we are good without it.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54445