### PR TITLE
[MM-54767] Fix potential deadlock in rtc test

### DIFF
--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	msgChSize        = 256
+	msgChSize        = 512
 	signalingTimeout = 10 * time.Second
 	catchAllIP       = "0.0.0.0"
 )

--- a/service/rtc/server_test.go
+++ b/service/rtc/server_test.go
@@ -483,6 +483,10 @@ func TestTCPCandidates(t *testing.T) {
 
 	err = s.Start()
 	require.NoError(t, err)
+	defer func() {
+		err := s.Stop()
+		require.NoError(t, err)
+	}()
 
 	cfg := SessionConfig{
 		GroupID:   random.NewID(),


### PR DESCRIPTION
#### Summary

Fixing a potential deadlock in tests. I mostly had to raise some channel sizes and rework the way we were queuing messages.

There's quite a bit of concurrency involved so can't be 100% certain the flakyness is completely gone but at least we should now be failing with timeout rather than deadlocking.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54767
