### PR TITLE
[MM-55415] Fix race condition on stop

### DIFF
--- a/service/rtc/server_test.go
+++ b/service/rtc/server_test.go
@@ -461,7 +461,7 @@ func TestCalls(t *testing.T) {
 func TestTCPCandidates(t *testing.T) {
 	log, err := logger.New(logger.Config{
 		EnableConsole: true,
-		ConsoleLevel:  "INFO",
+		ConsoleLevel:  "DEBUG",
 	})
 	require.NoError(t, err)
 	defer func() {

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -51,6 +51,7 @@ type session struct {
 
 	closeCh chan struct{}
 	closeCb func() error
+	doneWg  sync.WaitGroup
 
 	vadMonitor *vad.Monitor
 


### PR DESCRIPTION
#### Summary

Fixing this on our side for expediency. This race could cause a `panic` when stopping the server as closing the peer connection didn't guarantee for the `OnICECandidate` handler to be done so we'd go ahead and close the `receiveCh` which could still be written into, leading to a crash. 

I believe the race was introduced after the recent dependency upgrade, more specifically by https://github.com/pion/ice/commit/898746c1f52f0371579cf0720aacfd620a76c63b

I'll still see if I can send a patch upstream as I believe this sort of cases should be dealt with by the underlying API, essentially guaranteeing that after closing the `ice.Agent` no goroutines created by it would still be running.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-55415
