### PR TITLE
Fix linting on newer versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -292,8 +292,7 @@ go-run: ## to run locally for development
 prepare-plugin: ## prepare Calls plugin for testing
 ifeq (${CI}, true)
 	@$(INFO) preparing Calls plugin...
-	./build/test/prepare-plugin.sh && \
-	curl http://localhost:8065/plugins/com.mattermost.calls/version
+	./build/test/prepare-plugin.sh
 else
 	@$(INFO) skipping prepare-plugin target, not on CI
 endif

--- a/build/test/docker-compose.yaml
+++ b/build/test/docker-compose.yaml
@@ -20,7 +20,7 @@ services:
       retries: 3
 
   server:
-    image: "mattermostdevelopment/mm-ee-test:master"
+    image: "mattermostdevelopment/mattermost-enterprise-edition:master"
     restart: always
     network_mode: "host"
     environment:

--- a/build/test/prepare-plugin.sh
+++ b/build/test/prepare-plugin.sh
@@ -31,4 +31,10 @@ docker exec mmserver_server_1 bin/mmctl --local config patch config_patch.json &
 docker cp ${PLUGIN_BUILD_PATH} mmserver_server_1:/mattermost && \
 docker exec mmserver_server_1 bin/mmctl --local plugin delete ${PLUGIN_ID} && \
 docker exec mmserver_server_1 bin/mmctl --local plugin add ${PLUGIN_FILE_NAME} && \
-docker exec mmserver_server_1 bin/mmctl --local plugin enable ${PLUGIN_ID}
+docker exec mmserver_server_1 bin/mmctl --local plugin enable ${PLUGIN_ID} && \
+sleep 5s
+
+STATUS_CODE=$(curl --silent --head http://localhost:8065/plugins/com.mattermost.calls/version | awk '/^HTTP/{print $2}')
+if [ "$STATUS_CODE" != "200" ]; then
+  echo "Status code check for plugin failed" && docker logs mmserver_server_1 && exit 1
+fi

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -32,7 +32,7 @@ func TestClientConnect(t *testing.T) {
 
 	select {
 	case <-connectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for connect event")
 	}
 
@@ -41,7 +41,7 @@ func TestClientConnect(t *testing.T) {
 
 	select {
 	case <-closeCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for close event")
 	}
 }
@@ -160,13 +160,13 @@ func TestClientJoinCall(t *testing.T) {
 
 		select {
 		case <-connectCh:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for connect event")
 		}
 
 		select {
 		case <-errorCh:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for error event")
 		}
 
@@ -175,7 +175,7 @@ func TestClientJoinCall(t *testing.T) {
 
 		select {
 		case <-closeCh:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for close event")
 		}
 	})
@@ -206,13 +206,13 @@ func TestClientJoinCall(t *testing.T) {
 
 		select {
 		case <-connectCh:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for connect event")
 		}
 
 		select {
 		case <-joinCh:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for join event")
 		}
 
@@ -221,7 +221,7 @@ func TestClientJoinCall(t *testing.T) {
 
 		select {
 		case <-closeCh:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for close event")
 		}
 	})

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -35,12 +35,13 @@ type TestHelper struct {
 }
 
 const (
-	adminName = "sysadmin"
-	adminPass = "Sys@dmin-sample1"
-	userName  = "calls-user0"
-	userPass  = "U$er-sample1"
-	teamName  = "calls"
-	nChannels = 2
+	adminName   = "sysadmin"
+	adminPass   = "Sys@dmin-sample1"
+	userName    = "calls-user0"
+	userPass    = "U$er-sample1"
+	teamName    = "calls"
+	nChannels   = 2
+	waitTimeout = 5 * time.Second
 )
 
 func (th *TestHelper) transmitAudioTrack(c *Client) {

--- a/client/rtc_test.go
+++ b/client/rtc_test.go
@@ -37,7 +37,7 @@ func TestClientConnectCall(t *testing.T) {
 
 	select {
 	case <-rtcConnectCh:
-	case <-time.After(4 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for rtc connect event")
 	}
 
@@ -46,13 +46,13 @@ func TestClientConnectCall(t *testing.T) {
 
 	select {
 	case <-rtcDisconnectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for rtc disconnect event")
 	}
 
 	select {
 	case <-closeCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for close event")
 	}
 }
@@ -83,7 +83,7 @@ func TestRTCDisconnect(t *testing.T) {
 
 	select {
 	case <-rtcConnectCh:
-	case <-time.After(4 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for rtc connect event")
 	}
 
@@ -92,13 +92,13 @@ func TestRTCDisconnect(t *testing.T) {
 
 	select {
 	case <-rtcDisconnectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for rtc disconnect event")
 	}
 
 	select {
 	case <-closeCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for close event")
 	}
 }
@@ -154,13 +154,13 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-rtcConnectChA:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc connect event")
 		}
 
 		select {
 		case <-rtcConnectChB:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc connect event")
 		}
 
@@ -168,7 +168,7 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-rtcTrackCh:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc track event")
 		}
 
@@ -184,13 +184,13 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-closeChA:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for close event")
 		}
 
 		select {
 		case <-closeChB:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for close event")
 		}
 	})
@@ -238,7 +238,7 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-rtcConnectChB:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc connect event")
 		}
 
@@ -249,13 +249,13 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-rtcConnectChA:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc connect event")
 		}
 
 		select {
 		case <-rtcTrackCh:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc track event")
 		}
 
@@ -271,12 +271,12 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-closeChA:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 		}
 
 		select {
 		case <-closeChB:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for close event")
 		}
 	})
@@ -329,7 +329,7 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-rtcConnectChB:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc connect event")
 		}
 
@@ -344,13 +344,13 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-rtcConnectChA:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc connect event")
 		}
 
 		select {
 		case <-rtcTrackCh:
-		case <-time.After(4 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc track event")
 		}
 
@@ -366,13 +366,13 @@ func TestRTCTrack(t *testing.T) {
 
 		select {
 		case <-closeChA:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for close event")
 		}
 
 		select {
 		case <-closeChB:
-		case <-time.After(2 * time.Second):
+		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for close event")
 		}
 	})

--- a/client/websocket_test.go
+++ b/client/websocket_test.go
@@ -30,7 +30,7 @@ func TestClientWSDisconnect(t *testing.T) {
 
 	select {
 	case <-connectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for connect event")
 	}
 
@@ -39,7 +39,7 @@ func TestClientWSDisconnect(t *testing.T) {
 
 	select {
 	case <-disconnectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for disconnect event")
 	}
 
@@ -67,7 +67,7 @@ func TestClientWSReconnect(t *testing.T) {
 
 	select {
 	case <-connectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for connect event")
 	}
 
@@ -76,13 +76,13 @@ func TestClientWSReconnect(t *testing.T) {
 
 	select {
 	case <-disconnectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for disconnect event")
 	}
 
 	select {
 	case <-connectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for reconnect event")
 	}
 
@@ -106,7 +106,7 @@ func TestClientWSReconnectTimeout(t *testing.T) {
 
 	select {
 	case <-connectCh:
-	case <-time.After(2 * time.Second):
+	case <-time.After(waitTimeout):
 		require.Fail(t, "timed out waiting for connect event")
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	git.mills.io/prologic/bitcask v1.0.2
 	github.com/BurntSushi/toml v1.0.0
 	github.com/gorilla/websocket v1.5.1
-	github.com/grafana/pyroscope-go/godeltaprof v0.1.4
+	github.com/grafana/pyroscope-go/godeltaprof v0.1.7
 	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/mattermost/mattermost/server/public v0.0.12
 	github.com/pborman/uuid v1.2.1
@@ -39,6 +39,7 @@ require (
 	github.com/gofrs/flock v0.8.0 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/uuid v1.5.0 // indirect
+	github.com/klauspost/compress v1.17.7 // indirect
 	github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404 // indirect
 	github.com/mattermost/ldap v0.0.0-20231116144001-0f480c025956 // indirect
 	github.com/mattermost/logr/v2 v2.0.21 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00/go.mod h1:wJfORR
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.5.1 h1:gmztn0JnHVt9JZquRuzLw3g4wouNVzKL15iLr/zn/QY=
 github.com/gorilla/websocket v1.5.1/go.mod h1:x3kM2JMyaluk02fnUJpQuwD2dCS5NDG2ZHL0uE0tcaY=
-github.com/grafana/pyroscope-go/godeltaprof v0.1.4 h1:mDsJ3ngul7UfrHibGQpV66PbZ3q1T8glz/tK3bQKKEk=
-github.com/grafana/pyroscope-go/godeltaprof v0.1.4/go.mod h1:1HSPtjU8vLG0jE9JrTdzjgFqdJ/VgN7fvxBNq3luJko=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.7 h1:C11j63y7gymiW8VugJ9ZW0pWfxTZugdSJyC48olk5KY=
+github.com/grafana/pyroscope-go/godeltaprof v0.1.7/go.mod h1:Tk376Nbldo4Cha9RgiU7ik8WKFkNpfds98aUzS8omLE=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
@@ -258,6 +258,9 @@ github.com/kelseyhightower/envconfig v1.4.0/go.mod h1:cccZRl6mQpaq41TPp5QxidR+Sa
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.17.3/go.mod h1:/dCuZOvVtNoHsyb+cuJD3itjs3NbnF6KH9zAO4BDxPM=
+github.com/klauspost/compress v1.17.7 h1:ehO88t2UGzQK66LMdE8tibEd1ErmzZjNEqWkjLAKQQg=
+github.com/klauspost/compress v1.17.7/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=


### PR DESCRIPTION
#### Summary

Bumping the `github.com/grafana/pyroscope-go/godeltaprof` dependency as it's currently breaking `golangci-lint` on Go 1.22+

