### PR TITLE
[MM-57843] Add more API functionalities to client implementation

### DIFF
--- a/client/api.go
+++ b/client/api.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package client
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/pion/webrtc/v3"
+)
+
+const (
+	httpRequestTimeout           = 10 * time.Second
+	httpResponseBodyMaxSizeBytes = 1024 * 1024 // 1MB
+)
+
+func (c *Client) Unmute(track webrtc.TrackLocal) error {
+	if track == nil {
+		return fmt.Errorf("invalid nil track")
+	}
+
+	c.mut.RLock()
+	sender := c.voiceSender
+	c.mut.RUnlock()
+
+	if sender == nil {
+		snd, err := c.pc.AddTrack(track)
+		if err != nil {
+			return fmt.Errorf("failed to add track: %w", err)
+		}
+		c.mut.Lock()
+		c.voiceSender = snd
+		sender = snd
+		c.mut.Unlock()
+	} else {
+		if err := sender.ReplaceTrack(track); err != nil {
+			return fmt.Errorf("failed to replace track: %w", err)
+		}
+	}
+
+	go func() {
+		defer log.Printf("exiting RTCP handler")
+		rtcpBuf := make([]byte, receiveMTU)
+		for {
+			if _, _, rtcpErr := sender.Read(rtcpBuf); rtcpErr != nil {
+				log.Printf("failed to read rtcp: %s", rtcpErr.Error())
+				return
+			}
+		}
+	}()
+
+	return c.SendWS(wsEventUnmute, nil, false)
+}
+
+func (c *Client) Mute() error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	if c.voiceSender != nil {
+		if err := c.voiceSender.ReplaceTrack(nil); err != nil {
+			return fmt.Errorf("failed to replace track: %w", err)
+		}
+	}
+
+	return c.sendWS(wsEventMute, nil, false)
+}
+
+func (c *Client) StartScreenShare(tracks []webrtc.TrackLocal) (*webrtc.RTPTransceiver, error) {
+	if len(tracks) == 0 {
+		return nil, fmt.Errorf("invalid empty tracks")
+	}
+
+	if len(tracks) > 2 {
+		return nil, fmt.Errorf("too many tracks")
+	}
+
+	data, err := json.Marshal(map[string]string{
+		"screenStreamID": tracks[0].StreamID(),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal data: %w", err)
+	}
+
+	if err := c.SendWS(wsEventScreenOn, map[string]any{
+		"data": string(data),
+	}, false); err != nil {
+		return nil, fmt.Errorf("failed to send screen on event: %w", err)
+	}
+
+	trx, err := c.pc.AddTransceiverFromTrack(tracks[0], webrtc.RTPTransceiverInit{Direction: webrtc.RTPTransceiverDirectionSendonly})
+	if err != nil {
+		return nil, fmt.Errorf("failed to add transceiver for track: %w", err)
+	}
+
+	// Simulcast
+	if len(tracks) > 1 {
+		if err := trx.Sender().AddEncoding(tracks[1]); err != nil {
+			return nil, fmt.Errorf("failed to add encoding: %w", err)
+		}
+	}
+
+	c.mut.Lock()
+	c.screenTransceiver = trx
+	c.mut.Unlock()
+
+	sender := trx.Sender()
+
+	go func() {
+		defer log.Printf("exiting RTCP handler")
+		rtcpBuf := make([]byte, receiveMTU)
+		for {
+			if _, _, rtcpErr := sender.Read(rtcpBuf); rtcpErr != nil {
+				log.Printf("failed to read rtcp: %s", rtcpErr.Error())
+				return
+			}
+		}
+	}()
+
+	return trx, nil
+}
+
+func (c *Client) StopScreenShare() error {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+
+	if c.screenTransceiver != nil {
+		if err := c.pc.RemoveTrack(c.screenTransceiver.Sender()); err != nil {
+			return fmt.Errorf("failed to remove track: %w", err)
+		}
+		c.screenTransceiver = nil
+	}
+
+	return c.sendWS(wsEventScreenOff, nil, false)
+}
+
+func (c *Client) RaiseHand() error {
+	return c.SendWS(wsEventRaiseHand, nil, false)
+}
+
+func (c *Client) LowerHand() error {
+	return c.SendWS(wsEventLowerHand, nil, false)
+}
+
+func (c *Client) StartRecording() error {
+	ctx, cancel := context.WithTimeout(context.Background(), httpRequestTimeout)
+	defer cancel()
+	res, err := c.apiClient.DoAPIRequest(ctx, http.MethodPost,
+		fmt.Sprintf("%s/plugins/%s/calls/%s/recording/start", c.cfg.SiteURL, pluginID, c.cfg.ChannelID), "", "")
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("unexpected response status code %d", res.StatusCode)
+	}
+
+	return nil
+}
+
+func (c *Client) StopRecording() error {
+	ctx, cancel := context.WithTimeout(context.Background(), httpRequestTimeout)
+	defer cancel()
+	res, err := c.apiClient.DoAPIRequest(ctx, http.MethodPost,
+		fmt.Sprintf("%s/plugins/%s/calls/%s/recording/stop", c.cfg.SiteURL, pluginID, c.cfg.ChannelID), "", "")
+	if err != nil {
+		return fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return fmt.Errorf("unexpected response status code %d", res.StatusCode)
+	}
+
+	return nil
+}
+
+// TODO: return a proper Config object, ideally exposed in github.com/mattermost/mattermost-plugin-calls/server/public.
+func (c *Client) GetCallsConfig() (map[string]any, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), httpRequestTimeout)
+	defer cancel()
+	res, err := c.apiClient.DoAPIRequest(ctx, http.MethodGet,
+		fmt.Sprintf("%s/plugins/%s/config", c.cfg.SiteURL, pluginID), "", "")
+	if err != nil {
+		return nil, fmt.Errorf("request failed: %w", err)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected response status code %d", res.StatusCode)
+	}
+
+	dec := json.NewDecoder(&io.LimitedReader{
+		R: res.Body,
+		N: httpResponseBodyMaxSizeBytes,
+	})
+
+	var config map[string]any
+	if err := dec.Decode(&config); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+
+	return config, nil
+}

--- a/client/api.go
+++ b/client/api.go
@@ -28,6 +28,10 @@ func (c *Client) Unmute(track webrtc.TrackLocal) error {
 	c.mut.Lock()
 	defer c.mut.Unlock()
 
+	if c.pc == nil {
+		return fmt.Errorf("rtc client is not initialized")
+	}
+
 	sender := c.voiceSender
 
 	if sender == nil {
@@ -88,6 +92,10 @@ func (c *Client) StartScreenShare(tracks []webrtc.TrackLocal) (*webrtc.RTPTransc
 
 	c.mut.Lock()
 	defer c.mut.Unlock()
+
+	if c.pc == nil {
+		return nil, fmt.Errorf("rtc client is not initialized")
+	}
 
 	if err := c.sendWS(wsEventScreenOn, map[string]any{
 		"data": string(data),

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -41,6 +41,11 @@ func TestAPIMuteUnmute(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	t.Run("not initialized", func(t *testing.T) {
+		err := th.userClient.Unmute(th.newVoiceTrack())
+		require.EqualError(t, err, "rtc client is not initialized")
+	})
+
 	go func() {
 		err := th.userClient.Connect()
 		require.NoError(t, err)
@@ -376,6 +381,11 @@ func TestAPIScreenShare(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+
+	t.Run("not initialized", func(t *testing.T) {
+		_, err := th.userClient.StartScreenShare([]webrtc.TrackLocal{th.newScreenTrack()})
+		require.EqualError(t, err, "rtc client is not initialized")
+	})
 
 	go func() {
 		err := th.userClient.Connect()

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -75,7 +75,7 @@ func TestAPIMuteUnmute(t *testing.T) {
 	require.NoError(t, err)
 
 	userUnmutedCh := make(chan struct{})
-	err = th.adminClient.On(WSCallUserUnmuted, func(ctx any) error {
+	err = th.adminClient.On(WSCallUnmutedEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.userClient.originalConnID {
 			close(userUnmutedCh)
@@ -103,7 +103,7 @@ func TestAPIMuteUnmute(t *testing.T) {
 	}
 
 	userMutedCh := make(chan struct{})
-	err = th.adminClient.On(WSCallUserMuted, func(ctx any) error {
+	err = th.adminClient.On(WSCallMutedEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.userClient.originalConnID {
 			close(userMutedCh)
@@ -127,7 +127,7 @@ func TestAPIMuteUnmute(t *testing.T) {
 	require.NoError(t, err)
 
 	adminUnmutedCh := make(chan struct{})
-	err = th.userClient.On(WSCallUserUnmuted, func(ctx any) error {
+	err = th.userClient.On(WSCallUnmutedEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.adminClient.originalConnID {
 			close(adminUnmutedCh)
@@ -155,7 +155,7 @@ func TestAPIMuteUnmute(t *testing.T) {
 	}
 
 	adminMutedCh := make(chan struct{})
-	err = th.userClient.On(WSCallUserMuted, func(ctx any) error {
+	err = th.userClient.On(WSCallMutedEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.adminClient.originalConnID {
 			close(adminMutedCh)
@@ -252,7 +252,7 @@ func TestAPIRaiseLowerHand(t *testing.T) {
 	adminRaisedHandCh := make(chan struct{})
 	adminLoweredHandCh := make(chan struct{})
 
-	err = th.userClient.On(WSCallUserRaisedHand, func(ctx any) error {
+	err = th.userClient.On(WSCallRaisedHandEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.adminClient.originalConnID {
 			close(adminRaisedHandCh)
@@ -260,7 +260,7 @@ func TestAPIRaiseLowerHand(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	err = th.userClient.On(WSCallUserLoweredHand, func(ctx any) error {
+	err = th.userClient.On(WSCallLoweredHandEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.adminClient.originalConnID {
 			close(adminLoweredHandCh)
@@ -269,7 +269,7 @@ func TestAPIRaiseLowerHand(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = th.adminClient.On(WSCallUserRaisedHand, func(ctx any) error {
+	err = th.adminClient.On(WSCallRaisedHandEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.userClient.originalConnID {
 			close(userRaisedHandCh)
@@ -277,7 +277,7 @@ func TestAPIRaiseLowerHand(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
-	err = th.adminClient.On(WSCallUserLoweredHand, func(ctx any) error {
+	err = th.adminClient.On(WSCallLoweredHandEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.userClient.originalConnID {
 			close(userLoweredHandCh)
@@ -417,7 +417,7 @@ func TestAPIScreenShare(t *testing.T) {
 	require.NoError(t, err)
 
 	userScreenOnCh := make(chan struct{})
-	err = th.adminClient.On(WSCallScreenOn, func(ctx any) error {
+	err = th.adminClient.On(WSCallScreenOnEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.userClient.originalConnID {
 			close(userScreenOnCh)
@@ -439,7 +439,7 @@ func TestAPIScreenShare(t *testing.T) {
 	}
 
 	userScreenOffCh := make(chan struct{})
-	err = th.adminClient.On(WSCallScreenOff, func(ctx any) error {
+	err = th.adminClient.On(WSCallScreenOffEvent, func(ctx any) error {
 		sessionID := ctx.(string)
 		if sessionID == th.userClient.originalConnID {
 			close(userScreenOffCh)

--- a/client/api_test.go
+++ b/client/api_test.go
@@ -1,0 +1,495 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package client
+
+import (
+	"testing"
+	"time"
+
+	"github.com/pion/webrtc/v3"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAPIGetConfig(t *testing.T) {
+	th := setupTestHelper(t, "")
+
+	cfg, err := th.userClient.GetCallsConfig()
+	require.NoError(t, err)
+	require.NotEmpty(t, cfg)
+
+	require.True(t, cfg["AllowEnableCalls"].(bool))
+}
+
+func TestAPIMuteUnmute(t *testing.T) {
+	th := setupTestHelper(t, "calls0")
+
+	// Setup
+	userConnectCh := make(chan struct{})
+	err := th.userClient.On(RTCConnectEvent, func(_ any) error {
+		close(userConnectCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	adminConnectCh := make(chan struct{})
+	err = th.adminClient.On(RTCConnectEvent, func(_ any) error {
+		close(adminConnectCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	go func() {
+		err := th.userClient.Connect()
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := th.adminClient.Connect()
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-userConnectCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user connect event")
+	}
+
+	select {
+	case <-adminConnectCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for admin connect event")
+	}
+
+	// Test logic
+
+	userCloseCh := make(chan struct{})
+	adminCloseCh := make(chan struct{})
+
+	adminTrackCh := make(chan struct{})
+	err = th.adminClient.On(RTCTrackEvent, func(_ any) error {
+		close(adminTrackCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	userUnmutedCh := make(chan struct{})
+	err = th.adminClient.On(WSCallUserUnmuted, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.userClient.originalConnID {
+			close(userUnmutedCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// User unmutes, admin should receive the track
+	userVoiceTrack := th.newVoiceTrack()
+	err = th.userClient.Unmute(userVoiceTrack)
+	require.NoError(t, err)
+	go th.voiceTrackWriter(userVoiceTrack, userCloseCh)
+
+	select {
+	case <-userUnmutedCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user unmuted event")
+	}
+
+	select {
+	case <-adminTrackCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for admin client to receive track")
+	}
+
+	userMutedCh := make(chan struct{})
+	err = th.adminClient.On(WSCallUserMuted, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.userClient.originalConnID {
+			close(userMutedCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	err = th.userClient.Mute()
+	require.NoError(t, err)
+	select {
+	case <-userMutedCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user muted event")
+	}
+
+	userTrackCh := make(chan struct{})
+	err = th.userClient.On(RTCTrackEvent, func(_ any) error {
+		close(userTrackCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	adminUnmutedCh := make(chan struct{})
+	err = th.userClient.On(WSCallUserUnmuted, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.adminClient.originalConnID {
+			close(adminUnmutedCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	// Admin unmutes, user should receive the track
+	adminVoiceTrack := th.newVoiceTrack()
+	err = th.adminClient.Unmute(adminVoiceTrack)
+	require.NoError(t, err)
+	go th.voiceTrackWriter(adminVoiceTrack, adminCloseCh)
+
+	select {
+	case <-adminUnmutedCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for admin unmuted event")
+	}
+
+	select {
+	case <-userTrackCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user client to receive track")
+	}
+
+	adminMutedCh := make(chan struct{})
+	err = th.userClient.On(WSCallUserMuted, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.adminClient.originalConnID {
+			close(adminMutedCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	err = th.adminClient.Mute()
+	require.NoError(t, err)
+	select {
+	case <-adminMutedCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for admin muted event")
+	}
+
+	// Teardown
+	err = th.userClient.On(CloseEvent, func(_ any) error {
+		close(userCloseCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = th.adminClient.On(CloseEvent, func(_ any) error {
+		close(adminCloseCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	go func() {
+		err := th.userClient.Close()
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := th.adminClient.Close()
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-userCloseCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for close event")
+	}
+
+	select {
+	case <-adminCloseCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for close event")
+	}
+}
+
+func TestAPIRaiseLowerHand(t *testing.T) {
+	th := setupTestHelper(t, "calls0")
+
+	// Setup
+	userConnectCh := make(chan struct{})
+	err := th.userClient.On(RTCConnectEvent, func(_ any) error {
+		close(userConnectCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	adminConnectCh := make(chan struct{})
+	err = th.adminClient.On(RTCConnectEvent, func(_ any) error {
+		close(adminConnectCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	go func() {
+		err := th.userClient.Connect()
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := th.adminClient.Connect()
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-userConnectCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user connect event")
+	}
+
+	select {
+	case <-adminConnectCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for admin connect event")
+	}
+
+	userRaisedHandCh := make(chan struct{})
+	userLoweredHandCh := make(chan struct{})
+	adminRaisedHandCh := make(chan struct{})
+	adminLoweredHandCh := make(chan struct{})
+
+	err = th.userClient.On(WSCallUserRaisedHand, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.adminClient.originalConnID {
+			close(adminRaisedHandCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	err = th.userClient.On(WSCallUserLoweredHand, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.adminClient.originalConnID {
+			close(adminLoweredHandCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = th.adminClient.On(WSCallUserRaisedHand, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.userClient.originalConnID {
+			close(userRaisedHandCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+	err = th.adminClient.On(WSCallUserLoweredHand, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.userClient.originalConnID {
+			close(userLoweredHandCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = th.userClient.RaiseHand()
+	require.NoError(t, err)
+	select {
+	case <-userRaisedHandCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user raised hand event")
+	}
+
+	err = th.userClient.LowerHand()
+	require.NoError(t, err)
+	select {
+	case <-userLoweredHandCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user lowered hand event")
+	}
+
+	err = th.adminClient.RaiseHand()
+	require.NoError(t, err)
+	select {
+	case <-adminRaisedHandCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for admin raised hand event")
+	}
+
+	err = th.adminClient.LowerHand()
+	require.NoError(t, err)
+	select {
+	case <-adminLoweredHandCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for admin lowered hand event")
+	}
+
+	// Teardown
+
+	userCloseCh := make(chan struct{})
+	adminCloseCh := make(chan struct{})
+
+	err = th.userClient.On(CloseEvent, func(_ any) error {
+		close(userCloseCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = th.adminClient.On(CloseEvent, func(_ any) error {
+		close(adminCloseCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	go func() {
+		err := th.userClient.Close()
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := th.adminClient.Close()
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-userCloseCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for close event")
+	}
+
+	select {
+	case <-adminCloseCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for close event")
+	}
+}
+
+func TestAPIScreenShare(t *testing.T) {
+	th := setupTestHelper(t, "calls0")
+
+	// Setup
+	userConnectCh := make(chan struct{})
+	err := th.userClient.On(RTCConnectEvent, func(_ any) error {
+		close(userConnectCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	adminConnectCh := make(chan struct{})
+	err = th.adminClient.On(RTCConnectEvent, func(_ any) error {
+		close(adminConnectCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	go func() {
+		err := th.userClient.Connect()
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := th.adminClient.Connect()
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-userConnectCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user connect event")
+	}
+
+	select {
+	case <-adminConnectCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for admin connect event")
+	}
+
+	userCloseCh := make(chan struct{})
+	adminCloseCh := make(chan struct{})
+
+	// Test logic
+
+	// User screen shares, admin should receive the track
+	userScreenTrack := th.newScreenTrack()
+	_, err = th.userClient.StartScreenShare([]webrtc.TrackLocal{userScreenTrack})
+	require.NoError(t, err)
+	go th.screenTrackWriter(userScreenTrack, userCloseCh)
+
+	screenTrackCh := make(chan struct{})
+	err = th.adminClient.On(RTCTrackEvent, func(_ any) error {
+		close(screenTrackCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	userScreenOnCh := make(chan struct{})
+	err = th.adminClient.On(WSCallScreenOn, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.userClient.originalConnID {
+			close(userScreenOnCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-userScreenOnCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user screen on event")
+	}
+
+	select {
+	case <-screenTrackCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for screen track")
+	}
+
+	userScreenOffCh := make(chan struct{})
+	err = th.adminClient.On(WSCallScreenOff, func(ctx any) error {
+		sessionID := ctx.(string)
+		if sessionID == th.userClient.originalConnID {
+			close(userScreenOffCh)
+		}
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = th.userClient.StopScreenShare()
+	require.NoError(t, err)
+
+	select {
+	case <-userScreenOffCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for user screen off event")
+	}
+
+	// Teardown
+
+	err = th.userClient.On(CloseEvent, func(_ any) error {
+		close(userCloseCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	err = th.adminClient.On(CloseEvent, func(_ any) error {
+		close(adminCloseCh)
+		return nil
+	})
+	require.NoError(t, err)
+
+	go func() {
+		err := th.userClient.Close()
+		require.NoError(t, err)
+	}()
+
+	go func() {
+		err := th.adminClient.Close()
+		require.NoError(t, err)
+	}()
+
+	select {
+	case <-userCloseCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for close event")
+	}
+
+	select {
+	case <-adminCloseCh:
+	case <-time.After(waitTimeout):
+		require.Fail(t, "timed out waiting for close event")
+	}
+}

--- a/client/client.go
+++ b/client/client.go
@@ -23,41 +23,42 @@ type EventHandler func(ctx any) error
 type EventType string
 
 const (
-	WSConnectEvent         EventType = "WSConnect"
-	WSDisconnectEvent      EventType = "WSDisconnect"
-	WSCallJoinEvent        EventType = "WSCallJoin"
-	WSCallRecordingState   EventType = "WSCallRecordingState"
-	WSCallJobState         EventType = "WSCallJobState"
-	WSJobStopEvent         EventType = "WSStopJobEvent"
-	RTCConnectEvent        EventType = "RTCConnect"
-	RTCDisconnectEvent     EventType = "RTCDisconnect"
-	RTCTrackEvent          EventType = "RTCTrack"
-	CloseEvent             EventType = "Close"
-	ErrorEvent             EventType = "Error"
-	WSCallHostChangedEvent EventType = "WSCallHostChanged"
-	WSCallUserMuted        EventType = "WSCallUserMuted"
-	WSCallUserUnmuted      EventType = "WSCallUserUnmuted"
-	WSCallUserRaisedHand   EventType = "WSCallUserRaisedHand"
-	WSCallUserLoweredHand  EventType = "WSCallUserLoweredHand"
-	WSCallScreenOn         EventType = "WSCallScreenOn"
-	WSCallScreenOff        EventType = "WSCallScreenOff"
+	RTCConnectEvent    EventType = "RTCConnect"
+	RTCDisconnectEvent EventType = "RTCDisconnect"
+	RTCTrackEvent      EventType = "RTCTrack"
+
+	CloseEvent EventType = "Close"
+	ErrorEvent EventType = "Error"
+
+	WSConnectEvent            EventType = "WSConnect"
+	WSDisconnectEvent         EventType = "WSDisconnect"
+	WSCallJoinEvent           EventType = "WSCallJoin"
+	WSCallRecordingStateEvent EventType = "WSCallRecordingState" // DEPRECATED
+	WSCallJobStateEvent       EventType = "WSCallJobState"
+	WSJobStopEvent            EventType = "WSStopJobEvent"
+	WSCallHostChangedEvent    EventType = "WSCallHostChanged"
+	WSCallMutedEvent          EventType = "WSCallMuted"
+	WSCallUnmutedEvent        EventType = "WSCallUnmuted"
+	WSCallRaisedHandEvent     EventType = "WSCallRaisedHand"
+	WSCallLoweredHandEvent    EventType = "WSCallLoweredHand"
+	WSCallScreenOnEvent       EventType = "WSCallScreenOn"
+	WSCallScreenOffEvent      EventType = "WSCallScreenOff"
 )
 
 func (e EventType) IsValid() bool {
 	switch e {
-	case WSConnectEvent, WSDisconnectEvent,
-		WSCallJoinEvent,
-		WSCallRecordingState,
-		WSCallHostChangedEvent,
-		WSCallUserUnmuted, WSCallUserMuted,
-		WSCallUserLoweredHand, WSCallUserRaisedHand,
-		WSCallScreenOn, WSCallScreenOff,
-		WSCallJobState,
-		WSJobStopEvent,
-		RTCConnectEvent, RTCDisconnectEvent,
-		RTCTrackEvent,
+	case RTCConnectEvent, RTCDisconnectEvent, RTCTrackEvent,
 		CloseEvent,
-		ErrorEvent:
+		ErrorEvent,
+		WSConnectEvent, WSDisconnectEvent,
+		WSCallJoinEvent,
+		WSCallRecordingStateEvent,
+		WSCallHostChangedEvent,
+		WSCallUnmutedEvent, WSCallMutedEvent,
+		WSCallRaisedHandEvent, WSCallLoweredHandEvent,
+		WSCallScreenOnEvent, WSCallScreenOffEvent,
+		WSCallJobStateEvent,
+		WSJobStopEvent:
 		return true
 	default:
 		return false

--- a/client/client.go
+++ b/client/client.go
@@ -99,7 +99,7 @@ type Client struct {
 	pc                *webrtc.PeerConnection
 	dc                *webrtc.DataChannel
 	iceCh             chan webrtc.ICECandidateInit
-	receivers         map[string]*webrtc.RTPReceiver
+	receivers         map[string][]*webrtc.RTPReceiver
 	voiceSender       *webrtc.RTPSender
 	screenTransceiver *webrtc.RTPTransceiver
 
@@ -126,7 +126,7 @@ func New(cfg Config, opts ...Option) (*Client, error) {
 		wsCloseCh:     make(chan struct{}),
 		wsClientSeqNo: 1,
 		iceCh:         make(chan webrtc.ICECandidateInit, iceChSize),
-		receivers:     make(map[string]*webrtc.RTPReceiver),
+		receivers:     make(map[string][]*webrtc.RTPReceiver),
 		apiClient:     apiClient,
 	}
 

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -92,7 +92,7 @@ func (th *TestHelper) screenTrackWriter(track *webrtc.TrackLocalStaticRTP, close
 	}
 
 	// Send our video file frame at a time. Pace our sending so we send it at the same speed it should be played back as.
-	// This isn't required since the video is timestamped, but we will such much higher loss if we send all at once.
+	// This isn't required since the video is timestamped, but we will have much higher loss if we send all at once.
 	//
 	// It is important to use a time.Ticker instead of time.Sleep because
 	// * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -16,9 +16,13 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 
+	"github.com/pion/rtp"
+	"github.com/pion/rtp/codecs"
 	"github.com/pion/webrtc/v3"
 	"github.com/pion/webrtc/v3/pkg/media"
+	"github.com/pion/webrtc/v3/pkg/media/ivfreader"
 	"github.com/pion/webrtc/v3/pkg/media/oggreader"
+
 	"github.com/stretchr/testify/require"
 )
 
@@ -44,7 +48,95 @@ const (
 	waitTimeout = 5 * time.Second
 )
 
-func (th *TestHelper) transmitAudioTrack(c *Client) {
+func (th *TestHelper) newScreenTrack() *webrtc.TrackLocalStaticRTP {
+	th.tb.Helper()
+
+	track, err := webrtc.NewTrackLocalStaticRTP(webrtc.RTPCodecCapability{
+		MimeType:    "video/VP8",
+		ClockRate:   90000,
+		SDPFmtpLine: "",
+		RTCPFeedback: []webrtc.RTCPFeedback{
+			{Type: "goog-remb", Parameter: ""},
+			{Type: "ccm", Parameter: "fir"},
+			{Type: "nack", Parameter: ""},
+			{Type: "nack", Parameter: "pli"},
+		},
+	}, "screen", "screen_"+random.NewID())
+	require.NoError(th.tb, err)
+
+	return track
+}
+
+func (th *TestHelper) screenTrackWriter(track *webrtc.TrackLocalStaticRTP, closeCh <-chan struct{}) {
+	packetizer := rtp.NewPacketizer(
+		1200,
+		0,
+		0,
+		&codecs.VP8Payloader{
+			EnablePictureID: true,
+		},
+		rtp.NewRandomSequencer(),
+		90000,
+	)
+
+	// Open a IVF file and start reading using our IVFReader
+	file, ivfErr := os.Open("../testfiles/video.ivf")
+	if ivfErr != nil {
+		log.Fatalf(ivfErr.Error())
+	}
+	defer file.Close()
+
+	ivf, header, ivfErr := ivfreader.NewWith(file)
+	if ivfErr != nil {
+		log.Fatalf(ivfErr.Error())
+	}
+
+	// Send our video file frame at a time. Pace our sending so we send it at the same speed it should be played back as.
+	// This isn't required since the video is timestamped, but we will such much higher loss if we send all at once.
+	//
+	// It is important to use a time.Ticker instead of time.Sleep because
+	// * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
+	// * works around latency issues with Sleep (see https://github.com/golang/go/issues/44343)
+	frameDuration := time.Millisecond * time.Duration((float32(header.TimebaseNumerator)/float32(header.TimebaseDenominator))*1000)
+
+	ticker := time.NewTicker(frameDuration)
+	for {
+		select {
+		case <-closeCh:
+			log.Printf("existing ivf reader")
+			return
+		case <-ticker.C:
+		}
+
+		var frame []byte
+		var ivfErr error
+		frame, _, ivfErr = ivf.ParseNextFrame()
+		if ivfErr == io.EOF || (ivfErr != nil && ivfErr.Error() == "incomplete frame data") {
+			ivf.ResetReader(func(_ int64) io.Reader {
+				_, _ = file.Seek(0, 0)
+				ivf, header, ivfErr = ivfreader.NewWith(file)
+				if ivfErr != nil {
+					log.Fatalf(ivfErr.Error())
+				}
+				return file
+			})
+			frame, _, ivfErr = ivf.ParseNextFrame()
+		}
+		if ivfErr != nil {
+			log.Fatalf(ivfErr.Error())
+		}
+
+		packets := packetizer.Packetize(frame, 90000/header.TimebaseDenominator)
+		for _, p := range packets {
+			if err := track.WriteRTP(p); err != nil {
+				log.Printf("failed to write video sample: %s", err.Error())
+				return
+			}
+		}
+	}
+}
+
+func (th *TestHelper) newVoiceTrack() *webrtc.TrackLocalStaticSample {
 	th.tb.Helper()
 
 	track, err := webrtc.NewTrackLocalStaticSample(webrtc.RTPCodecCapability{
@@ -55,6 +147,67 @@ func (th *TestHelper) transmitAudioTrack(c *Client) {
 		RTCPFeedback: nil,
 	}, "audio", "voice_"+random.NewID())
 	require.NoError(th.tb, err)
+
+	return track
+}
+
+func (th *TestHelper) voiceTrackWriter(track *webrtc.TrackLocalStaticSample, closeCh <-chan struct{}) {
+	th.tb.Helper()
+
+	// Open a OGG file and start reading using our OGGReader
+	file, oggErr := os.Open("../testfiles/audio.ogg")
+	require.NoError(th.tb, oggErr)
+	defer file.Close()
+
+	// Open on oggfile in non-checksum mode.
+	ogg, _, oggErr := oggreader.NewWith(file)
+	require.NoError(th.tb, oggErr)
+
+	// Keep track of last granule, the difference is the amount of samples in the buffer
+	var lastGranule uint64
+
+	// It is important to use a time.Ticker instead of time.Sleep because
+	// * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
+	// * works around latency issues with Sleep (see https://github.com/golang/go/issues/44343)
+	oggPageDuration := time.Millisecond * 20
+	ticker := time.NewTicker(oggPageDuration)
+	for {
+		select {
+		case <-closeCh:
+			log.Printf("existing ogg reader")
+			return
+		case <-ticker.C:
+		}
+
+		var oggErr error
+		var pageData []byte
+		var pageHeader *oggreader.OggPageHeader
+		pageData, pageHeader, oggErr = ogg.ParseNextPage()
+		if oggErr == io.EOF {
+			ogg.ResetReader(func(_ int64) io.Reader {
+				_, _ = file.Seek(0, 0)
+				return file
+			})
+			pageData, pageHeader, oggErr = ogg.ParseNextPage()
+		}
+		require.NoError(th.tb, oggErr)
+
+		// The amount of samples is the difference between the last and current timestamp
+		sampleCount := float64(pageHeader.GranulePosition - lastGranule)
+		lastGranule = pageHeader.GranulePosition
+		sampleDuration := time.Duration((sampleCount/48000)*1000) * time.Millisecond
+
+		if err := track.WriteSample(media.Sample{Data: pageData, Duration: sampleDuration}); err != nil {
+			log.Printf("failed to write audio sample: %s", err)
+			return
+		}
+	}
+}
+
+func (th *TestHelper) transmitAudioTrack(c *Client) {
+	th.tb.Helper()
+
+	track := th.newVoiceTrack()
 
 	sender, err := c.pc.AddTrack(track)
 	require.NoError(th.tb, err)
@@ -71,56 +224,7 @@ func (th *TestHelper) transmitAudioTrack(c *Client) {
 		}
 	}()
 
-	go func() {
-		// Open a OGG file and start reading using our OGGReader
-		file, oggErr := os.Open("../testfiles/audio.ogg")
-		require.NoError(th.tb, oggErr)
-		defer file.Close()
-
-		// Open on oggfile in non-checksum mode.
-		ogg, _, oggErr := oggreader.NewWith(file)
-		require.NoError(th.tb, oggErr)
-
-		// Keep track of last granule, the difference is the amount of samples in the buffer
-		var lastGranule uint64
-
-		// It is important to use a time.Ticker instead of time.Sleep because
-		// * avoids accumulating skew, just calling time.Sleep didn't compensate for the time spent parsing the data
-		// * works around latency issues with Sleep (see https://github.com/golang/go/issues/44343)
-		oggPageDuration := time.Millisecond * 20
-		ticker := time.NewTicker(oggPageDuration)
-		for {
-			select {
-			case <-closeCh:
-				log.Printf("existing ogg reader")
-				return
-			case <-ticker.C:
-			}
-
-			var oggErr error
-			var pageData []byte
-			var pageHeader *oggreader.OggPageHeader
-			pageData, pageHeader, oggErr = ogg.ParseNextPage()
-			if oggErr == io.EOF {
-				ogg.ResetReader(func(_ int64) io.Reader {
-					_, _ = file.Seek(0, 0)
-					return file
-				})
-				pageData, pageHeader, oggErr = ogg.ParseNextPage()
-			}
-			require.NoError(th.tb, oggErr)
-
-			// The amount of samples is the difference between the last and current timestamp
-			sampleCount := float64(pageHeader.GranulePosition - lastGranule)
-			lastGranule = pageHeader.GranulePosition
-			sampleDuration := time.Duration((sampleCount/48000)*1000) * time.Millisecond
-
-			if err := track.WriteSample(media.Sample{Data: pageData, Duration: sampleDuration}); err != nil {
-				log.Printf("failed to write audio sample: %s", err)
-				return
-			}
-		}
-	}()
+	go th.voiceTrackWriter(track, closeCh)
 }
 
 func (th *TestHelper) ensureUser(client *model.Client4, username, password string) *model.User {

--- a/client/rtc.go
+++ b/client/rtc.go
@@ -238,7 +238,7 @@ func (c *Client) initRTCSession() error {
 		}
 
 		c.mut.Lock()
-		c.receivers[sessionID] = receiver
+		c.receivers[sessionID] = append(c.receivers[sessionID], receiver)
 		c.mut.Unlock()
 
 		// RTCP handler
@@ -259,7 +259,10 @@ func (c *Client) initRTCSession() error {
 			}
 		}(track.RID())
 
-		c.emit(RTCTrackEvent, track)
+		c.emit(RTCTrackEvent, map[string]any{
+			"track":    track,
+			"receiver": receiver,
+		})
 	})
 
 	pc.OnNegotiationNeeded(func() {

--- a/client/rtc.go
+++ b/client/rtc.go
@@ -169,7 +169,9 @@ func (c *Client) initRTCSession() error {
 	if err != nil {
 		return fmt.Errorf("failed to create new peer connection: %s", err)
 	}
+	c.mut.Lock()
 	c.pc = pc
+	c.mut.Unlock()
 
 	pc.OnICECandidate(func(candidate *webrtc.ICECandidate) {
 		if candidate == nil {

--- a/client/rtc_test.go
+++ b/client/rtc_test.go
@@ -15,24 +15,27 @@ func TestClientConnectCall(t *testing.T) {
 	th := setupTestHelper(t, "calls0")
 
 	closeCh := make(chan struct{})
-	th.userClient.On(CloseEvent, func(_ any) error {
+	err := th.userClient.On(CloseEvent, func(_ any) error {
 		close(closeCh)
 		return nil
 	})
+	require.NoError(t, err)
 
 	rtcConnectCh := make(chan struct{})
-	th.userClient.On(RTCConnectEvent, func(_ any) error {
+	err = th.userClient.On(RTCConnectEvent, func(_ any) error {
 		close(rtcConnectCh)
 		return nil
 	})
+	require.NoError(t, err)
 
 	rtcDisconnectCh := make(chan struct{})
-	th.userClient.On(RTCDisconnectEvent, func(_ any) error {
+	err = th.userClient.On(RTCDisconnectEvent, func(_ any) error {
 		close(rtcDisconnectCh)
 		return nil
 	})
+	require.NoError(t, err)
 
-	err := th.userClient.Connect()
+	err = th.userClient.Connect()
 	require.NoError(t, err)
 
 	select {
@@ -61,24 +64,27 @@ func TestRTCDisconnect(t *testing.T) {
 	th := setupTestHelper(t, "calls0")
 
 	closeCh := make(chan struct{})
-	th.userClient.On(CloseEvent, func(_ any) error {
+	err := th.userClient.On(CloseEvent, func(_ any) error {
 		close(closeCh)
 		return nil
 	})
+	require.NoError(t, err)
 
 	rtcConnectCh := make(chan struct{})
-	th.userClient.On(RTCConnectEvent, func(_ any) error {
+	err = th.userClient.On(RTCConnectEvent, func(_ any) error {
 		close(rtcConnectCh)
 		return nil
 	})
+	require.NoError(t, err)
 
 	rtcDisconnectCh := make(chan struct{})
-	th.userClient.On(RTCDisconnectEvent, func(_ any) error {
+	err = th.userClient.On(RTCDisconnectEvent, func(_ any) error {
 		close(rtcDisconnectCh)
 		return nil
 	})
+	require.NoError(t, err)
 
-	err := th.userClient.Connect()
+	err = th.userClient.Connect()
 	require.NoError(t, err)
 
 	select {
@@ -108,31 +114,35 @@ func TestRTCTrack(t *testing.T) {
 		th := setupTestHelper(t, "calls0")
 
 		rtcConnectChA := make(chan struct{})
-		th.userClient.On(RTCConnectEvent, func(_ any) error {
+		err := th.userClient.On(RTCConnectEvent, func(_ any) error {
 			close(rtcConnectChA)
 			return nil
 		})
+		require.NoError(t, err)
 
 		rtcConnectChB := make(chan struct{})
-		th.adminClient.On(RTCConnectEvent, func(_ any) error {
+		err = th.adminClient.On(RTCConnectEvent, func(_ any) error {
 			close(rtcConnectChB)
 			return nil
 		})
+		require.NoError(t, err)
 
 		closeChA := make(chan struct{})
-		th.userClient.On(CloseEvent, func(_ any) error {
+		err = th.userClient.On(CloseEvent, func(_ any) error {
 			close(closeChA)
 			return nil
 		})
+		require.NoError(t, err)
 
 		closeChB := make(chan struct{})
-		th.adminClient.On(CloseEvent, func(_ any) error {
+		err = th.adminClient.On(CloseEvent, func(_ any) error {
 			close(closeChB)
 			return nil
 		})
+		require.NoError(t, err)
 
 		rtcTrackCh := make(chan struct{})
-		th.userClient.On(RTCTrackEvent, func(ctx any) error {
+		err = th.userClient.On(RTCTrackEvent, func(ctx any) error {
 			track, ok := ctx.(*webrtc.TrackRemote)
 			require.True(t, ok)
 			require.Equal(t, webrtc.PayloadType(0x6f), track.PayloadType())
@@ -141,6 +151,7 @@ func TestRTCTrack(t *testing.T) {
 			close(rtcTrackCh)
 			return nil
 		})
+		require.NoError(t, err)
 
 		go func() {
 			err := th.userClient.Connect()
@@ -199,31 +210,35 @@ func TestRTCTrack(t *testing.T) {
 		th := setupTestHelper(t, "calls0")
 
 		rtcConnectChA := make(chan struct{})
-		th.userClient.On(RTCConnectEvent, func(_ any) error {
+		err := th.userClient.On(RTCConnectEvent, func(_ any) error {
 			close(rtcConnectChA)
 			return nil
 		})
+		require.NoError(t, err)
 
 		rtcConnectChB := make(chan struct{})
-		th.adminClient.On(RTCConnectEvent, func(_ any) error {
+		err = th.adminClient.On(RTCConnectEvent, func(_ any) error {
 			close(rtcConnectChB)
 			return nil
 		})
+		require.NoError(t, err)
 
 		closeChA := make(chan struct{})
-		th.userClient.On(CloseEvent, func(_ any) error {
+		err = th.userClient.On(CloseEvent, func(_ any) error {
 			close(closeChA)
 			return nil
 		})
+		require.NoError(t, err)
 
 		closeChB := make(chan struct{})
-		th.adminClient.On(CloseEvent, func(_ any) error {
+		err = th.adminClient.On(CloseEvent, func(_ any) error {
 			close(closeChB)
 			return nil
 		})
+		require.NoError(t, err)
 
 		rtcTrackCh := make(chan struct{})
-		th.userClient.On(RTCTrackEvent, func(ctx any) error {
+		err = th.userClient.On(RTCTrackEvent, func(ctx any) error {
 			track, ok := ctx.(*webrtc.TrackRemote)
 			require.True(t, ok)
 			require.Equal(t, webrtc.PayloadType(0x6f), track.PayloadType())
@@ -232,8 +247,9 @@ func TestRTCTrack(t *testing.T) {
 			close(rtcTrackCh)
 			return nil
 		})
+		require.NoError(t, err)
 
-		err := th.adminClient.Connect()
+		err = th.adminClient.Connect()
 		require.NoError(t, err)
 
 		select {
@@ -285,31 +301,35 @@ func TestRTCTrack(t *testing.T) {
 		th := setupTestHelper(t, "calls0")
 
 		rtcConnectChA := make(chan struct{})
-		th.userClient.On(RTCConnectEvent, func(_ any) error {
+		err := th.userClient.On(RTCConnectEvent, func(_ any) error {
 			close(rtcConnectChA)
 			return nil
 		})
+		require.NoError(t, err)
 
 		rtcConnectChB := make(chan struct{})
-		th.adminClient.On(RTCConnectEvent, func(_ any) error {
+		err = th.adminClient.On(RTCConnectEvent, func(_ any) error {
 			close(rtcConnectChB)
 			return nil
 		})
+		require.NoError(t, err)
 
 		closeChA := make(chan struct{})
-		th.userClient.On(CloseEvent, func(_ any) error {
+		err = th.userClient.On(CloseEvent, func(_ any) error {
 			close(closeChA)
 			return nil
 		})
+		require.NoError(t, err)
 
 		closeChB := make(chan struct{})
-		th.adminClient.On(CloseEvent, func(_ any) error {
+		err = th.adminClient.On(CloseEvent, func(_ any) error {
 			close(closeChB)
 			return nil
 		})
+		require.NoError(t, err)
 
 		rtcTrackCh := make(chan struct{})
-		th.userClient.On(RTCTrackEvent, func(ctx any) error {
+		err = th.userClient.On(RTCTrackEvent, func(ctx any) error {
 			track, ok := ctx.(*webrtc.TrackRemote)
 			require.True(t, ok)
 			require.Equal(t, webrtc.PayloadType(0x6f), track.PayloadType())
@@ -323,8 +343,9 @@ func TestRTCTrack(t *testing.T) {
 			close(rtcTrackCh)
 			return nil
 		})
+		require.NoError(t, err)
 
-		err := th.adminClient.Connect()
+		err = th.adminClient.Connect()
 		require.NoError(t, err)
 
 		select {

--- a/client/rtc_test.go
+++ b/client/rtc_test.go
@@ -143,7 +143,9 @@ func TestRTCTrack(t *testing.T) {
 
 		rtcTrackCh := make(chan struct{})
 		err = th.userClient.On(RTCTrackEvent, func(ctx any) error {
-			track, ok := ctx.(*webrtc.TrackRemote)
+			ctxMap, ok := ctx.(map[string]any)
+			require.True(t, ok)
+			track, ok := ctxMap["track"].(*webrtc.TrackRemote)
 			require.True(t, ok)
 			require.Equal(t, webrtc.PayloadType(0x6f), track.PayloadType())
 			require.Equal(t, "audio/opus", track.Codec().MimeType)
@@ -239,7 +241,9 @@ func TestRTCTrack(t *testing.T) {
 
 		rtcTrackCh := make(chan struct{})
 		err = th.userClient.On(RTCTrackEvent, func(ctx any) error {
-			track, ok := ctx.(*webrtc.TrackRemote)
+			ctxMap, ok := ctx.(map[string]any)
+			require.True(t, ok)
+			track, ok := ctxMap["track"].(*webrtc.TrackRemote)
 			require.True(t, ok)
 			require.Equal(t, webrtc.PayloadType(0x6f), track.PayloadType())
 			require.Equal(t, "audio/opus", track.Codec().MimeType)
@@ -330,7 +334,9 @@ func TestRTCTrack(t *testing.T) {
 
 		rtcTrackCh := make(chan struct{})
 		err = th.userClient.On(RTCTrackEvent, func(ctx any) error {
-			track, ok := ctx.(*webrtc.TrackRemote)
+			ctxMap, ok := ctx.(map[string]any)
+			require.True(t, ok)
+			track, ok := ctxMap["track"].(*webrtc.TrackRemote)
 			require.True(t, ok)
 			require.Equal(t, webrtc.PayloadType(0x6f), track.PayloadType())
 			require.Equal(t, "audio/opus", track.Codec().MimeType)
@@ -374,6 +380,140 @@ func TestRTCTrack(t *testing.T) {
 		case <-time.After(waitTimeout):
 			require.Fail(t, "timed out waiting for rtc track event")
 		}
+
+		go func() {
+			err := th.userClient.Close()
+			require.NoError(t, err)
+		}()
+
+		go func() {
+			err := th.adminClient.Close()
+			require.NoError(t, err)
+		}()
+
+		select {
+		case <-closeChA:
+		case <-time.After(waitTimeout):
+			require.Fail(t, "timed out waiting for close event")
+		}
+
+		select {
+		case <-closeChB:
+		case <-time.After(waitTimeout):
+			require.Fail(t, "timed out waiting for close event")
+		}
+	})
+
+	t.Run("multiple remote tracks per session", func(t *testing.T) {
+		th := setupTestHelper(t, "calls0")
+
+		rtcConnectChA := make(chan struct{})
+		err := th.userClient.On(RTCConnectEvent, func(_ any) error {
+			close(rtcConnectChA)
+			return nil
+		})
+		require.NoError(t, err)
+
+		rtcConnectChB := make(chan struct{})
+		err = th.adminClient.On(RTCConnectEvent, func(_ any) error {
+			close(rtcConnectChB)
+			return nil
+		})
+		require.NoError(t, err)
+
+		go func() {
+			err := th.adminClient.Connect()
+			require.NoError(t, err)
+		}()
+
+		go func() {
+			err := th.userClient.Connect()
+			require.NoError(t, err)
+		}()
+
+		select {
+		case <-rtcConnectChA:
+		case <-time.After(waitTimeout):
+			require.Fail(t, "timed out waiting for rtc connect event")
+		}
+
+		select {
+		case <-rtcConnectChB:
+		case <-time.After(waitTimeout):
+			require.Fail(t, "timed out waiting for rtc connect event")
+		}
+
+		voiceTrackCh := make(chan struct{})
+		screenTrackCh := make(chan struct{})
+		err = th.adminClient.On(RTCTrackEvent, func(ctx any) error {
+			ctxMap, ok := ctx.(map[string]any)
+			require.True(t, ok)
+			track, ok := ctxMap["track"].(*webrtc.TrackRemote)
+			require.True(t, ok)
+
+			receiver, ok := ctxMap["receiver"].(*webrtc.RTPReceiver)
+			require.True(t, ok)
+			require.Equal(t, track, receiver.Track())
+
+			trackType, sessionID, err := ParseTrackID(track.ID())
+			require.NoError(t, err)
+
+			require.Equal(t, th.userClient.originalConnID, sessionID)
+
+			if trackType == TrackTypeVoice {
+				require.Equal(t, webrtc.PayloadType(0x6f), track.PayloadType())
+				require.Equal(t, "audio/opus", track.Codec().MimeType)
+				close(voiceTrackCh)
+			} else if trackType == TrackTypeScreen {
+				require.Equal(t, webrtc.PayloadType(0x60), track.PayloadType())
+				require.Equal(t, "video/VP8", track.Codec().MimeType)
+				close(screenTrackCh)
+			} else {
+				require.Fail(t, "unexpected track type received")
+			}
+
+			return nil
+		})
+		require.NoError(t, err)
+
+		go func() {
+			th.transmitAudioTrack(th.userClient)
+		}()
+
+		go func() {
+			th.transmitScreenTrack(th.userClient)
+		}()
+
+		select {
+		case <-voiceTrackCh:
+		case <-time.After(waitTimeout):
+			require.Fail(t, "timed out waiting for voice track")
+		}
+
+		select {
+		case <-screenTrackCh:
+		case <-time.After(waitTimeout):
+			require.Fail(t, "timed out waiting for screen track")
+		}
+
+		th.userClient.mut.RLock()
+		require.Len(t, th.adminClient.receivers, 1)
+		require.Len(t, th.adminClient.receivers[th.userClient.originalConnID], 2)
+		th.userClient.mut.RUnlock()
+
+		closeChA := make(chan struct{})
+		err = th.userClient.On(CloseEvent, func(_ any) error {
+			close(closeChA)
+			return nil
+		})
+		require.NoError(t, err)
+
+		closeChB := make(chan struct{})
+		err = th.adminClient.On(CloseEvent, func(_ any) error {
+			close(closeChB)
+			return nil
+		})
+		require.NoError(t, err)
 
 		go func() {
 			err := th.userClient.Close()

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -190,7 +190,7 @@ func (c *Client) handleWSMsg(msg ws.Message) error {
 				return fmt.Errorf("missing session_id from user_left event")
 			}
 			c.mut.Lock()
-			if rx := c.receivers[sessionID]; rx != nil {
+			for _, rx := range c.receivers[sessionID] {
 				log.Printf("stopping receiver for disconnected session %q", sessionID)
 				if err := rx.Stop(); err != nil {
 					log.Printf("failed to stop receiver for session %q: %s", sessionID, err)

--- a/client/websocket_test.go
+++ b/client/websocket_test.go
@@ -14,18 +14,20 @@ func TestClientWSDisconnect(t *testing.T) {
 	th := setupTestHelper(t, "")
 
 	connectCh := make(chan struct{}, 2)
-	th.userClient.On(WSConnectEvent, func(_ any) error {
+	err := th.userClient.On(WSConnectEvent, func(_ any) error {
 		connectCh <- struct{}{}
 		return nil
 	})
+	require.NoError(t, err)
 
 	disconnectCh := make(chan struct{})
-	th.userClient.On(WSDisconnectEvent, func(_ any) error {
+	err = th.userClient.On(WSDisconnectEvent, func(_ any) error {
 		close(disconnectCh)
 		return nil
 	})
+	require.NoError(t, err)
 
-	err := th.userClient.Connect()
+	err = th.userClient.Connect()
 	require.NoError(t, err)
 
 	select {
@@ -51,18 +53,20 @@ func TestClientWSReconnect(t *testing.T) {
 	th := setupTestHelper(t, "")
 
 	connectCh := make(chan struct{}, 2)
-	th.userClient.On(WSConnectEvent, func(_ any) error {
+	err := th.userClient.On(WSConnectEvent, func(_ any) error {
 		connectCh <- struct{}{}
 		return nil
 	})
+	require.NoError(t, err)
 
 	disconnectCh := make(chan struct{})
-	th.userClient.On(WSDisconnectEvent, func(_ any) error {
+	err = th.userClient.On(WSDisconnectEvent, func(_ any) error {
 		close(disconnectCh)
 		return nil
 	})
+	require.NoError(t, err)
 
-	err := th.userClient.Connect()
+	err = th.userClient.Connect()
 	require.NoError(t, err)
 
 	select {
@@ -96,12 +100,13 @@ func TestClientWSReconnectTimeout(t *testing.T) {
 	th := setupTestHelper(t, "")
 
 	connectCh := make(chan struct{}, 2)
-	th.userClient.On(WSConnectEvent, func(_ any) error {
+	err := th.userClient.On(WSConnectEvent, func(_ any) error {
 		connectCh <- struct{}{}
 		return nil
 	})
+	require.NoError(t, err)
 
-	err := th.userClient.Connect()
+	err = th.userClient.Connect()
 	require.NoError(t, err)
 
 	select {
@@ -113,17 +118,19 @@ func TestClientWSReconnectTimeout(t *testing.T) {
 	th.userClient.cfg.wsURL = "ws://localhost:8080"
 
 	errorCh := make(chan struct{})
-	th.userClient.On(ErrorEvent, func(ctx any) error {
+	err = th.userClient.On(ErrorEvent, func(ctx any) error {
 		close(errorCh)
 		require.EqualError(t, ctx.(error), "ws reconnection timeout reached")
 		return nil
 	})
+	require.NoError(t, err)
 
 	closeCh := make(chan struct{})
-	th.userClient.On(CloseEvent, func(_ any) error {
+	err = th.userClient.On(CloseEvent, func(_ any) error {
 		close(closeCh)
 		return nil
 	})
+	require.NoError(t, err)
 
 	err = th.userClient.ws.Close()
 	require.NoError(t, err)


### PR DESCRIPTION
#### Summary

PR implements some of the core functionalities we were missing from `rtcd.Client`. This effectively becomes the official (and public) Golang implementation for a Mattermost Calls capable client.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-57843
