### PR TITLE
[MM-58136] Support advanced mapping for ice host port override

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -61,6 +61,21 @@ ice_host_override = ""
 # Note: this port will apply to both UDP and TCP host candidates.
 #
 # ice_host_port_override = 30443
+#
+# This setting supports an advanced syntax that can be used to provide a full mapping
+# of local addresses and the port that should be used to override the generated host candidate.
+#
+# Example:
+#
+# ice_host_override      = "8.8.8.8"
+# ice_host_port_override = "localIPA/8443,localIPB/8444,localIPC/8445"
+#
+# In the above example, if the rtcd process is running on an instance with localIPA it will override
+# the port of the host candidate using the address 8.8.8.8 with 8443.
+#
+# A reason to set a full mapping, including addresses of other instances, is to make it possible to pass the same
+# config to multiple pods in Kubernetes deployments. In that case, each pod should match against one
+# local (node) IP and greatly simplify load balancing across multiple nodes.
 
 # A list of ICE servers (STUN/TURN) to be used by the service. It supports
 # advanced configurations.

--- a/docs/env_config.md
+++ b/docs/env_config.md
@@ -15,7 +15,7 @@ RTCD_RTC_ICEPORTUDP                                 Integer
 RTCD_RTC_ICEADDRESSTCP                              String
 RTCD_RTC_ICEPORTTCP                                 Integer
 RTCD_RTC_ICEHOSTOVERRIDE                            String
-RTCD_RTC_ICEHOSTPORTOVERRIDE                        Integer
+RTCD_RTC_ICEHOSTPORTOVERRIDE                        ICEHostPortOverride
 RTCD_RTC_ICESERVERS                                 Comma-separated list of 
 RTCD_RTC_TURNCONFIG_STATICAUTHSECRET                String
 RTCD_RTC_TURNCONFIG_CREDENTIALSEXPIRATIONMINUTES    Integer

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -105,6 +105,19 @@ func (s *Server) Start() error {
 
 	s.log.Debug("rtc: found local IPs", mlog.Any("ips", s.localIPs))
 
+	if m, _ := s.cfg.ICEHostPortOverride.ParseMap(); len(m) > 0 {
+		s.log.Debug("rtc: found ice host port override mappings", mlog.Any("mappings", s.cfg.ICEHostPortOverride))
+
+		for _, ip := range localIPs {
+			if port, ok := m[ip.String()]; ok {
+				s.log.Debug("rtc: found port override for local address", mlog.String("address", ip.String()), mlog.Int("port", port))
+				s.cfg.ICEHostPortOverride = ICEHostPortOverride(fmt.Sprintf("%d", port))
+				// NOTE: currently not supporting multiple ip/port mappings for the same rtcd instance.
+				break
+			}
+		}
+	}
+
 	// Populate public IP addresses map if override is not set and STUN is provided.
 	if s.cfg.ICEHostOverride == "" && len(s.cfg.ICEServers) > 0 {
 		for _, ip := range localIPs {

--- a/service/rtc/utils.go
+++ b/service/rtc/utils.go
@@ -127,3 +127,19 @@ func generateAddrsPairs(localIPs []netip.Addr, publicAddrsMap map[netip.Addr]str
 
 	return pairs, nil
 }
+
+func getExternalAddrMapFromHostOverride(override string) map[string]bool {
+	if override == "" {
+		return nil
+	}
+
+	pairs := strings.Split(override, ",")
+	m := make(map[string]bool, len(pairs))
+
+	for _, p := range pairs {
+		pair := strings.Split(p, "/")
+		m[pair[0]] = true
+	}
+
+	return m
+}

--- a/service/rtc/utils_test.go
+++ b/service/rtc/utils_test.go
@@ -154,3 +154,26 @@ func TestIsValidTrackID(t *testing.T) {
 		})
 	}
 }
+
+func TestGetExternalAddrMapFromHostOverride(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		m := getExternalAddrMapFromHostOverride("")
+		require.Empty(t, m)
+	})
+
+	t.Run("single host", func(t *testing.T) {
+		m := getExternalAddrMapFromHostOverride("10.0.0.1")
+		require.Equal(t, map[string]bool{
+			"10.0.0.1": true,
+		}, m)
+	})
+
+	t.Run("mapping", func(t *testing.T) {
+		m := getExternalAddrMapFromHostOverride("10.0.0.1/127.0.0.1,10.0.0.3/127.0.0.2,10.0.0.2/127.0.0.3")
+		require.Equal(t, map[string]bool{
+			"10.0.0.1": true,
+			"10.0.0.2": true,
+			"10.0.0.3": true,
+		}, m)
+	})
+}


### PR DESCRIPTION
#### Summary

PR adds support for a more advanced syntax in the `rtc.ice_host_port_override` config setting which takes the following form:

`localIPA/externalPortA,localIPB/externalPortB`

This becomes useful in deployments that are exposing a single public IP address and hence must be using different port numbers to map against multiple rtcd services listening internally. 

The reason to pass a full mapping is to make it possible to deploy in Kubernetes where the config passed must be the same across all the pods in the deployment. Each rtcd instance will only use the port override that maps to its local IP.

/cc @coltoneshaw 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-58136
