### PR TITLE
[MM-54335] Improve write concurrency for screen tracks

### DIFF
--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -43,7 +43,7 @@ func (c *call) addSession(cfg SessionConfig, rtcConn *webrtc.PeerConnection, clo
 		closeCh:            make(chan struct{}),
 		closeCb:            closeCb,
 		tracksCh:           make(chan trackActionContext, tracksChSize),
-		outScreenTracks:    make(map[string]*webrtc.TrackLocalStaticRTP),
+		outScreenTracks:    make(map[string][]*webrtc.TrackLocalStaticRTP),
 		remoteScreenTracks: make(map[string]*webrtc.TrackRemote),
 		screenRateMonitors: make(map[string]*RateMonitor),
 		log:                log,
@@ -181,8 +181,10 @@ func (c *call) handleSessionClose(us *session) {
 	if us.outScreenAudioTrack != nil {
 		outTracks[us.outScreenAudioTrack.ID()] = true
 	}
-	for _, track := range us.outScreenTracks {
-		outTracks[track.ID()] = true
+	for _, tracks := range us.outScreenTracks {
+		for _, track := range tracks {
+			outTracks[track.ID()] = true
+		}
 	}
 
 	// Nothing left to do if the closing session wasn't sending anything.

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"sync"
 	"time"
 
@@ -150,11 +149,7 @@ func (s *session) getOutScreenTrack(rid string) *webrtc.TrackLocalStaticRTP {
 	s.mut.RLock()
 	defer s.mut.RUnlock()
 
-	if len(s.outScreenTracks[rid]) == 0 {
-		return nil
-	}
-
-	return s.outScreenTracks[rid][rand.Intn(len(s.outScreenTracks))]
+	return pickRandom(s.outScreenTracks[rid])
 }
 
 func (s *session) getExpectedSimulcastLevel() string {

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"os"
 	"runtime"
 	"time"
@@ -731,7 +730,7 @@ func (s *Server) handleTracks(call *call, us *session) {
 			outTracks = append(outTracks, outVoiceTrack)
 		}
 		if len(outScreenTracks) > 0 {
-			outTracks = append(outTracks, outScreenTracks[rand.Intn(len(outScreenTracks))])
+			outTracks = append(outTracks, pickRandom(outScreenTracks))
 		}
 		if outScreenAudioTrack != nil {
 			outTracks = append(outTracks, outScreenAudioTrack)

--- a/service/rtc/utils.go
+++ b/service/rtc/utils.go
@@ -5,6 +5,7 @@ package rtc
 
 import (
 	"fmt"
+	"math/rand"
 	"net/netip"
 	"strings"
 	"time"
@@ -142,4 +143,11 @@ func getExternalAddrMapFromHostOverride(override string) map[string]bool {
 	}
 
 	return m
+}
+
+func pickRandom[S ~[]*E, E any](s S) *E {
+	if len(s) == 0 {
+		return nil
+	}
+	return s[rand.Intn(len(s))]
 }


### PR DESCRIPTION
#### Summary

Initial ceiling tests identified a bottleneck when writing screen tracks in large calls (> 250 participants). This is because the write loop runs on a single goroutine since we use a single output track. This results in the CPU not being utilized to the fullest and packets getting significantly delayed or even dropped. 

To overcome the current limitation, this PR proposes to create N output tracks and concurrently write to them. 

These changes are showing to improve overall performance and CPU utilization on our target instance (`c7i.xlarge`) by a factor of ~2.5, getting us from around 300 participants to 800 per call with near-zero packet loss.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-54335