### PR TITLE
[MM-58136] Don't use port override for local addresses

### DIFF
--- a/service/rtc/utils.go
+++ b/service/rtc/utils.go
@@ -133,12 +133,24 @@ func getExternalAddrMapFromHostOverride(override string) map[string]bool {
 		return nil
 	}
 
+	m := make(map[string]bool)
+
+	if !strings.Contains(override, "/") {
+		m[override] = true
+		return m
+	}
+
 	pairs := strings.Split(override, ",")
-	m := make(map[string]bool, len(pairs))
 
 	for _, p := range pairs {
 		pair := strings.Split(p, "/")
-		m[pair[0]] = true
+		if len(pair) != 2 {
+			continue
+		}
+
+		if pair[0] != pair[1] {
+			m[pair[0]] = true
+		}
 	}
 
 	return m

--- a/service/rtc/utils_test.go
+++ b/service/rtc/utils_test.go
@@ -176,4 +176,12 @@ func TestGetExternalAddrMapFromHostOverride(t *testing.T) {
 			"10.0.0.3": true,
 		}, m)
 	})
+
+	t.Run("mixed mapping", func(t *testing.T) {
+		m := getExternalAddrMapFromHostOverride("10.0.0.1/127.0.0.1,127.0.0.2/127.0.0.2,10.0.0.2/127.0.0.3")
+		require.Equal(t, map[string]bool{
+			"10.0.0.1": true,
+			"10.0.0.2": true,
+		}, m)
+	})
 }


### PR DESCRIPTION
#### Summary

A small (but potentially significant) fix on https://github.com/mattermost/rtcd/pull/137.

We shouldn't override the port for local addresses as they could appear in the map (mapped to themselves) which is a valid case.
