### PR TITLE
[MM-58136] Apply port override to public addresses found through STUN

### DIFF
--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -251,8 +251,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 		}
 
 		if port := s.cfg.ICEHostPortOverride.SinglePort(); port != 0 && candidate.Typ == webrtc.ICECandidateTypeHost {
-			m := getExternalAddrMapFromHostOverride(s.cfg.ICEHostOverride)
-			if m[candidate.Address] {
+			if m := getExternalAddrMapFromHostOverride(s.cfg.ICEHostOverride, s.publicAddrsMap); m[candidate.Address] {
 				s.log.Debug("overriding host candidate port",
 					mlog.String("sessionID", cfg.SessionID),
 					mlog.Uint("port", candidate.Port),

--- a/service/rtc/utils.go
+++ b/service/rtc/utils.go
@@ -128,20 +128,25 @@ func generateAddrsPairs(localIPs []netip.Addr, publicAddrsMap map[netip.Addr]str
 	return pairs, nil
 }
 
-func getExternalAddrMapFromHostOverride(override string) map[string]bool {
-	if override == "" {
-		return nil
-	}
-
+func getExternalAddrMapFromHostOverride(override string, publicAddrsMap map[netip.Addr]string) map[string]bool {
 	m := make(map[string]bool)
 
+	// If the override is empty we add any external address found through STUN.
+	if override == "" {
+		for _, addr := range publicAddrsMap {
+			m[addr] = true
+		}
+		return m
+	}
+
+	// If the override is set and it's a single address we only need that.
 	if !strings.Contains(override, "/") {
 		m[override] = true
 		return m
 	}
 
+	// Otherwise we need to add all the external addresses passed through the advanced syntax.
 	pairs := strings.Split(override, ",")
-
 	for _, p := range pairs {
 		pair := strings.Split(p, "/")
 		if len(pair) != 2 {

--- a/service/rtc/utils_test.go
+++ b/service/rtc/utils_test.go
@@ -157,19 +157,19 @@ func TestIsValidTrackID(t *testing.T) {
 
 func TestGetExternalAddrMapFromHostOverride(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
-		m := getExternalAddrMapFromHostOverride("")
+		m := getExternalAddrMapFromHostOverride("", nil)
 		require.Empty(t, m)
 	})
 
 	t.Run("single host", func(t *testing.T) {
-		m := getExternalAddrMapFromHostOverride("10.0.0.1")
+		m := getExternalAddrMapFromHostOverride("10.0.0.1", nil)
 		require.Equal(t, map[string]bool{
 			"10.0.0.1": true,
 		}, m)
 	})
 
 	t.Run("mapping", func(t *testing.T) {
-		m := getExternalAddrMapFromHostOverride("10.0.0.1/127.0.0.1,10.0.0.3/127.0.0.2,10.0.0.2/127.0.0.3")
+		m := getExternalAddrMapFromHostOverride("10.0.0.1/127.0.0.1,10.0.0.3/127.0.0.2,10.0.0.2/127.0.0.3", nil)
 		require.Equal(t, map[string]bool{
 			"10.0.0.1": true,
 			"10.0.0.2": true,
@@ -178,10 +178,19 @@ func TestGetExternalAddrMapFromHostOverride(t *testing.T) {
 	})
 
 	t.Run("mixed mapping", func(t *testing.T) {
-		m := getExternalAddrMapFromHostOverride("10.0.0.1/127.0.0.1,127.0.0.2/127.0.0.2,10.0.0.2/127.0.0.3")
+		m := getExternalAddrMapFromHostOverride("10.0.0.1/127.0.0.1,127.0.0.2/127.0.0.2,10.0.0.2/127.0.0.3", nil)
 		require.Equal(t, map[string]bool{
 			"10.0.0.1": true,
 			"10.0.0.2": true,
+		}, m)
+	})
+
+	t.Run("public address map", func(t *testing.T) {
+		m := getExternalAddrMapFromHostOverride("", map[netip.Addr]string{
+			netip.MustParseAddr("127.0.0.1"): "10.0.0.1",
+		})
+		require.Equal(t, map[string]bool{
+			"10.0.0.1": true,
 		}, m)
 	})
 }


### PR DESCRIPTION
#### Summary

Covering another case which we'll need to unblock https://mattermost.atlassian.net/browse/CLD-7443. The port override should also apply to public addresses found through STUN since they effectively become host overrides.

