### PR TITLE
Fix race in `CloseSession`

### DIFF
--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -42,6 +42,7 @@ func (c *call) addSession(cfg SessionConfig, rtcConn *webrtc.PeerConnection, clo
 		sdpAnswerInCh:      make(chan webrtc.SessionDescription, signalChSize),
 		closeCh:            make(chan struct{}),
 		closeCb:            closeCb,
+		doneCh:             make(chan struct{}),
 		tracksCh:           make(chan trackActionContext, tracksChSize),
 		outScreenTracks:    make(map[string][]*webrtc.TrackLocalStaticRTP),
 		remoteScreenTracks: make(map[string]*webrtc.TrackRemote),

--- a/service/rtc/server_test.go
+++ b/service/rtc/server_test.go
@@ -248,12 +248,17 @@ func TestInitSession(t *testing.T) {
 		}
 	}
 
+	var wg sync.WaitGroup
+	wg.Add(len(sessions))
 	for _, cfg := range sessions {
 		go func(cfg SessionConfig) {
+			defer wg.Done()
 			err := s.InitSession(cfg, nil)
 			require.NoError(t, err)
 		}(cfg)
 	}
+
+	wg.Wait()
 
 	for _, cfg := range sessions {
 		go func(id string) {

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -51,7 +51,7 @@ type session struct {
 
 	closeCh chan struct{}
 	closeCb func() error
-	doneWg  sync.WaitGroup
+	doneCh  chan struct{}
 
 	vadMonitor *vad.Monitor
 

--- a/service/rtc/session_test.go
+++ b/service/rtc/session_test.go
@@ -50,6 +50,8 @@ func TestAddSession(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, us)
 
+		close(us.doneCh)
+
 		err = server.CloseSession(cfg.SessionID)
 		require.NoError(t, err)
 	})
@@ -80,6 +82,8 @@ func TestAddSession(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, us)
 
+		close(us.doneCh)
+
 		err = server.CloseSession(cfg.SessionID)
 		require.Error(t, err)
 		require.Equal(t, cbError, err)
@@ -87,6 +91,8 @@ func TestAddSession(t *testing.T) {
 		us, err = server.addSession(cfg, peerConn, closeCbSuccess)
 		require.NoError(t, err)
 		require.NotNil(t, us)
+
+		close(us.doneCh)
 
 		err = server.CloseSession(cfg.SessionID)
 		require.NoError(t, err)
@@ -111,6 +117,8 @@ func TestCloseSessionConcurrent(t *testing.T) {
 	us, err := server.addSession(cfg, peerConn, nil)
 	require.NoError(t, err)
 	require.NotNil(t, us)
+
+	close(us.doneCh)
 
 	var wg sync.WaitGroup
 	n := 20


### PR DESCRIPTION
#### Summary

A test spotted a failure unrelated to the changes. Fixing the race seen in https://github.com/mattermost/rtcd/actions/runs/9198822361/job/25302371765?pr=141

Using a channel instead of the `sync.WaitGroup` is simpler.



