### PR TITLE
Bump Node version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Install Node
       uses: actions/setup-node@v2
       with:
-        node-version: '18.17'
+        node-version: '20.11'
     - name: Checkout Code
       uses: actions/checkout@v2
       with:


### PR DESCRIPTION
#### Summary

This is needed since https://github.com/mattermost/mattermost-plugin-calls/pull/700 went in.


