### PR TITLE
[MM-45236] Improve auditing of joining sessions

### DIFF
--- a/service/rtc/config.go
+++ b/service/rtc/config.go
@@ -74,6 +74,15 @@ type SessionConfig struct {
 	UserID string
 	// SessionID specifies the unique identifier for the session.
 	SessionID string
+	Props     map[string]any
+}
+
+func (c *SessionConfig) GetStringProp(key string) string {
+	if c == nil || c.Props == nil {
+		return ""
+	}
+	val, _ := c.Props[key].(string)
+	return val
 }
 
 func (c SessionConfig) IsValid() error {

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -652,6 +652,13 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 		<-iceDoneCh
 	}()
 
+	s.log.Debug("session has joined call",
+		mlog.String("userID", cfg.UserID),
+		mlog.String("sessionID", cfg.SessionID),
+		mlog.String("channelID", cfg.GetStringProp("channelID")),
+		mlog.String("callID", cfg.CallID),
+	)
+
 	return nil
 }
 

--- a/service/service.go
+++ b/service/service.go
@@ -296,6 +296,7 @@ func (s *Service) handleClientMsg(msg ws.Message) error {
 		if sessionID == "" {
 			return fmt.Errorf("missing sessionID in client message")
 		}
+		channelID := data["channelID"]
 
 		closeCb := func() error {
 			s.mut.Lock()
@@ -321,8 +322,13 @@ func (s *Service) handleClientMsg(msg ws.Message) error {
 			CallID:    callID,
 			UserID:    userID,
 			SessionID: sessionID,
+			Props: map[string]any{
+				"channelID": channelID,
+			},
 		}
+
 		s.log.Debug("join message", mlog.Any("sessionCfg", cfg))
+
 		if err := s.rtcServer.InitSession(cfg, closeCb); err != nil {
 			return fmt.Errorf("failed to initialize rtc session: %w", err)
 		}


### PR DESCRIPTION
#### Summary

PR improves logging of which sessions join calls, including all the most important IDs.

Example:

```
debug [2024-06-05 14:44:32.751 +02:00] session has joined call                       caller="rtc/sfu.go:655" userID=zjm6x7y4n3gjzfj7kw3xp9c9se sessionID=5dbfn67ubtr3fkhqb9octcu5iy channelID=oi18bftr738ntn35xnyjyed9uh callID=g3y3k1to57y85puaccnwgj7ber
```

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-45236

