### PR TITLE
Prevent log warnings and errors for mac

### DIFF
--- a/service/rtc/net.go
+++ b/service/rtc/net.go
@@ -108,12 +108,15 @@ func createUDPConnsForAddr(log mlog.LoggerIFace, network, listenAddress string) 
 			log.Info(fmt.Sprintf("rtc: server is listening on udp %s", listenAddress))
 		}
 
-		if err := udpConn.(*net.UDPConn).SetWriteBuffer(udpSocketBufferSize); err != nil {
-			log.Warn("rtc: failed to set udp send buffer", mlog.Err(err))
-		}
+		// Mac by default cannot set socket buffers > 8mb
+		if runtime.GOOS != "darwin" {
+			if err := udpConn.(*net.UDPConn).SetWriteBuffer(udpSocketBufferSize); err != nil {
+				log.Warn("rtc: failed to set udp send buffer", mlog.Err(err))
+			}
 
-		if err := udpConn.(*net.UDPConn).SetReadBuffer(udpSocketBufferSize); err != nil {
-			log.Warn("rtc: failed to set udp receive buffer", mlog.Err(err))
+			if err := udpConn.(*net.UDPConn).SetReadBuffer(udpSocketBufferSize); err != nil {
+				log.Warn("rtc: failed to set udp receive buffer", mlog.Err(err))
+			}
 		}
 
 		connFile, err := udpConn.(*net.UDPConn).File()


### PR DESCRIPTION
#### Summary
- This fixes two issues on mac:
  - the `failed to set udp receive buffer` and `failed to set udp send buffer` warnings on startup.
  - the `failed to get cpu stat` error every second once it's started.
- Since we don't support mac, don't set udp buffers for mac, don't start the stat polling, and return a 404 on the system endpoint when it's mac (the plugin will use the random fallback).
- For the curious: For the snd_buf and rcvbuf, it looks like mac's max socket buf is 8mb, that's why it's failing. You can't increase that unless you increase the mbuf clusters, and you can't do that (I tried) without booting into recovery mode and disabling security settings. For stat, Mac doesn't have /proc/stat, it has sysctl.
- Tests don't need to be changed, since they're run on a linux container. Would be an interesting challenge to build a darwin container... :) 

#### Ticket Link
- none