### PR TITLE
[MM-57029] Remove redundant push step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -156,7 +156,7 @@ build: go-build-docker ## to build
 release: build github-release ## to build and release artifacts
 
 .PHONY: package
-package: docker-login docker-build docker-push ## to build, package and push the artifact to a container registry
+package: docker-login docker-build ## to build, package and push the artifact to a container registry
 
 .PHONY: sign
 sign: docker-sign docker-verify ## to sign the artifact and perform verification
@@ -193,20 +193,6 @@ ifeq ($(shell git tag -l --sort=v:refname | tail -n1),$(APP_VERSION))
 	-t ${DOCKER_REGISTRY}/${DOCKER_REGISTRY_REPO}:latest || ${FAIL}
 endif
 endif
-
-.PHONY: docker-push
-docker-push: ## to push the docker image
-	@$(INFO) Pushing to registry...
-	$(AT)$(DOCKER) tag ${APP_NAME}:${APP_VERSION} $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}:${APP_VERSION} || ${FAIL}
-	$(AT)$(DOCKER) push $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}:${APP_VERSION} || ${FAIL}
-# if we are on a latest semver APP_VERSION tag, also push latest
-ifneq ($(shell echo $(APP_VERSION) | egrep '^v([0-9]+\.){0,2}(\*|[0-9]+)'),)
-  ifeq ($(shell git tag -l --sort=v:refname | tail -n1),$(APP_VERSION))
-	$(AT)$(DOCKER) tag ${APP_NAME}:${APP_VERSION} $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}:latest || ${FAIL}
-	$(AT)$(DOCKER) push $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}:latest || ${FAIL}
-  endif
-endif
-	@$(OK) Pushing to registry $(DOCKER_REGISTRY)/${DOCKER_REGISTRY_REPO}:${APP_VERSION}
 
 .PHONY: docker-sign
 docker-sign: ## to sign the docker image

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -2,7 +2,7 @@
 # A multi stage build, with golang used as a builder
 # and gcr.io/distroless/static as runner
 ARG GO_VERSION
-FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} as builder
+FROM --platform=$BUILDPLATFORM golang:${GO_VERSION} AS builder
 ARG TARGETOS
 ARG TARGETARCH
 ARG GO_BUILD_PLATFORMS=${TARGETOS}-${TARGETARCH}
@@ -14,7 +14,7 @@ RUN make go-build
 
 # Shrink final image since we only need the rtcd binary
 # and use distroless container image as runner for security
-FROM --platform=$TARGETPLATFORM gcr.io/distroless/static@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f as runner
+FROM --platform=$TARGETPLATFORM gcr.io/distroless/static@sha256:d6fa9db9548b5772860fecddb11d84f9ebd7e0321c0cb3c02870402680cc315f AS runner
 ARG TARGETOS
 ARG TARGETARCH
 COPY --from=builder /src/dist/rtcd-${TARGETOS}-${TARGETARCH} /opt/rtcd/bin/rtcd


### PR DESCRIPTION
#### Summary

I forgot to remove the redundant push step, which is causing the release pipeline to fail. The images are already published automatically by the building process.



