### PR TITLE
[MM-59548] Fix potentially stuck goroutines

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/pion/sctp v1.8.16 // indirect
 	github.com/pion/sdp/v3 v3.0.9 // indirect
 	github.com/pion/srtp/v2 v2.0.18 // indirect
-	github.com/pion/transport/v2 v2.2.5 // indirect
+	github.com/pion/transport/v2 v2.2.4 // indirect
 	github.com/pion/turn/v2 v2.1.6 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/plar/go-adaptive-radix-tree v1.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -346,6 +346,7 @@ github.com/pion/stun v0.6.1/go.mod h1:/hO7APkX4hZKu/D0f2lHzNyvdkTGtIy3NDmLR7kSz/
 github.com/pion/transport/v2 v2.2.1/go.mod h1:cXXWavvCnFF6McHTft3DWS9iic2Mftcz1Aq29pGcU5g=
 github.com/pion/transport/v2 v2.2.2/go.mod h1:OJg3ojoBJopjEeECq2yJdXH9YVrUJ1uQ++NjXLOUorc=
 github.com/pion/transport/v2 v2.2.3/go.mod h1:q2U/tf9FEfnSBGSW6w5Qp5PFWRLRj3NjLhCCgpRK4p0=
+github.com/pion/transport/v2 v2.2.4 h1:41JJK6DZQYSeVLxILA2+F4ZkKb4Xd/tFJZRFZQ9QAlo=
 github.com/pion/transport/v2 v2.2.4/go.mod h1:q2U/tf9FEfnSBGSW6w5Qp5PFWRLRj3NjLhCCgpRK4p0=
 github.com/pion/transport/v2 v2.2.5 h1:iyi25i/21gQck4hfRhomF6SktmUQjRsRW4WJdhfc3Kc=
 github.com/pion/transport/v2 v2.2.5/go.mod h1:q2U/tf9FEfnSBGSW6w5Qp5PFWRLRj3NjLhCCgpRK4p0=

--- a/service/client_test.go
+++ b/service/client_test.go
@@ -632,6 +632,8 @@ func TestClientGetVersionInfo(t *testing.T) {
 			BuildDate:    buildDate,
 			BuildVersion: buildVersion,
 			GoVersion:    runtime.Version(),
+			GoOS:         runtime.GOOS,
+			GoArch:       runtime.GOARCH,
 		}, info)
 	})
 }

--- a/service/version.go
+++ b/service/version.go
@@ -22,6 +22,8 @@ type VersionInfo struct {
 	BuildVersion string `json:"buildVersion"`
 	BuildHash    string `json:"buildHash"`
 	GoVersion    string `json:"goVersion"`
+	GoOS         string `json:"goOS"`
+	GoArch       string `json:"goArch"`
 }
 
 func getVersionInfo() VersionInfo {
@@ -30,6 +32,8 @@ func getVersionInfo() VersionInfo {
 		BuildVersion: buildVersion,
 		BuildHash:    buildHash,
 		GoVersion:    runtime.Version(),
+		GoOS:         runtime.GOOS,
+		GoArch:       runtime.GOARCH,
 	}
 }
 
@@ -39,6 +43,8 @@ func (v VersionInfo) logFields() []mlog.Field {
 		mlog.String("buildVersion", v.BuildVersion),
 		mlog.String("buildHash", v.BuildHash),
 		mlog.String("goVersion", v.GoVersion),
+		mlog.String("goOS", v.GoOS),
+		mlog.String("goArch", v.GoArch),
 	}
 }
 

--- a/service/version_test.go
+++ b/service/version_test.go
@@ -44,6 +44,8 @@ func TestGetVersion(t *testing.T) {
 			BuildDate:    buildDate,
 			BuildVersion: buildVersion,
 			GoVersion:    goVersion,
+			GoOS:         runtime.GOOS,
+			GoArch:       runtime.GOARCH,
 		}, info)
 	})
 
@@ -58,6 +60,8 @@ func TestGetVersion(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, VersionInfo{
 			GoVersion: goVersion,
+			GoOS:      runtime.GOOS,
+			GoArch:    runtime.GOARCH,
 		}, info)
 	})
 }


### PR DESCRIPTION
#### Summary

Looking at goroutines profiles highlighted a couple of (unrelated) issues:

1. Some read calls on incoming voice tracks can suddenly block due to an apparent regression upstream (`pion/transport`). 	  	
	- This is still under investigation. Downgrading to the previous version is enough to prevent the issue while a fix is found.
2. The `CloseSession` could get stuck indefinitely in case of a timeout during the initial signaling phase due to a circular check on the session's done channel.
	- Reworked the function to preemptively close the channel in these fail-early cases.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-59548
