### PR TITLE
Fix CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ endif
 start-mm: ## start MM server
 ifeq (${CI}, true)
 	@$(INFO) starting up MM server...
-	docker-compose -p mmserver -f ./build/test/docker-compose.yaml up -d
+	docker compose -p mmserver -f ./build/test/docker-compose.yaml up -d
 else
 	@$(INFO) skipping start-mm target, not on CI
 endif
@@ -338,7 +338,7 @@ endif
 stop-mm: ## stop MM server
 ifeq (${CI}, true)
 	@$(INFO) stopping up MM server...
-	docker-compose -p mmserver -f ./build/test/docker-compose.yaml down
+	docker compose -p mmserver -f ./build/test/docker-compose.yaml down
 else
 	@$(INFO) skipping stop-mm target, not on CI
 endif

--- a/build/test/docker-compose.yaml
+++ b/build/test/docker-compose.yaml
@@ -39,6 +39,7 @@ services:
       MM_SERVICESETTINGS_ENABLEONBOARDINGFLOW: "false"
       MM_FEATUREFLAGS_ONBOARDINGTOURTIPS: "false"
       MM_SERVICEENVIRONMENT: "test"
+      MM_CALLS_GROUP_CALLS_ALLOWED: "true"
     volumes:
     - "server-config:/mattermost/config"
     depends_on:


### PR DESCRIPTION
#### Summary

There were a couple of issues:

- The deprecated `docker-compose` command was used. This also meant the MM container name used for e2e tests had to be updated.
- Since we didn't fetch git tags, the version in the manifest wasn't generated properly causing a parsing failure.
- Testing against the plugin would fail as we merged the v1 breaking changes to limit calls to DMs only. 


