### PR TITLE
[MM-60189] Rate limit forwarding PLI requests

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -23,9 +23,10 @@ type EventHandler func(ctx any) error
 type EventType string
 
 const (
-	RTCConnectEvent    EventType = "RTCConnect"
-	RTCDisconnectEvent EventType = "RTCDisconnect"
-	RTCTrackEvent      EventType = "RTCTrack"
+	RTCConnectEvent          EventType = "RTCConnect"
+	RTCDisconnectEvent       EventType = "RTCDisconnect"
+	RTCTrackEvent            EventType = "RTCTrack"
+	RTCSenderRTCPPacketEvent EventType = "RTCSenderRTCPPacket"
 
 	CloseEvent EventType = "Close"
 	ErrorEvent EventType = "Error"
@@ -47,7 +48,7 @@ const (
 
 func (e EventType) IsValid() bool {
 	switch e {
-	case RTCConnectEvent, RTCDisconnectEvent, RTCTrackEvent,
+	case RTCConnectEvent, RTCDisconnectEvent, RTCTrackEvent, RTCSenderRTCPPacketEvent,
 		CloseEvent,
 		ErrorEvent,
 		WSConnectEvent, WSDisconnectEvent,

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"os"
 	"testing"
 	"time"
@@ -45,7 +46,7 @@ const (
 	userPass    = "U$er-sample1"
 	teamName    = "calls"
 	nChannels   = 2
-	waitTimeout = 5 * time.Second
+	waitTimeout = 10 * time.Second
 )
 
 func (th *TestHelper) newScreenTrack(mimeType string) *webrtc.TrackLocalStaticRTP {
@@ -326,6 +327,11 @@ func setupTestHelper(tb testing.TB, channelName string) *TestHelper {
 	tb.Helper()
 	var err error
 
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+
 	th := &TestHelper{
 		tb:       tb,
 		channels: make(map[string]*model.Channel),
@@ -354,7 +360,7 @@ func setupTestHelper(tb testing.TB, channelName string) *TestHelper {
 		SiteURL:   th.apiURL,
 		AuthToken: th.adminAPIClient.AuthToken,
 		ChannelID: channelID,
-	})
+	}, WithLogger(logger))
 	require.NoError(tb, err)
 	require.NotNil(tb, th.adminClient)
 
@@ -362,7 +368,7 @@ func setupTestHelper(tb testing.TB, channelName string) *TestHelper {
 		SiteURL:   th.apiURL,
 		AuthToken: th.userAPIClient.AuthToken,
 		ChannelID: channelID,
-	})
+	}, WithLogger(logger))
 	require.NoError(tb, err)
 	require.NotNil(tb, th.userClient)
 

--- a/client/rtc.go
+++ b/client/rtc.go
@@ -256,8 +256,9 @@ func (c *Client) initRTCSession() error {
 
 		// RTCP handler
 		go func(rid string) {
+			var err error
+			rtcpBuf := make([]byte, receiveMTU)
 			for {
-				rtcpBuf := make([]byte, receiveMTU)
 				if rid != "" {
 					_, _, err = receiver.ReadSimulcast(rtcpBuf, rid)
 				} else {

--- a/client/rtc.go
+++ b/client/rtc.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 
 	"github.com/pion/interceptor"
+	"github.com/pion/rtcp"
 	"github.com/pion/webrtc/v3"
 )
 
@@ -240,6 +241,13 @@ func (c *Client) initRTCSession() error {
 				c.log.Error("failed to stop receiver", slog.String("err", err.Error()))
 			}
 			return
+		}
+
+		if trackType == TrackTypeScreen {
+			c.log.Debug("sending PLI request for received screen track", slog.String("trackID", track.ID()), slog.Any("SSRC", track.SSRC()))
+			if err := pc.WriteRTCP([]rtcp.Packet{&rtcp.PictureLossIndication{MediaSSRC: uint32(track.SSRC())}}); err != nil {
+				c.log.Error("failed to write RTCP packet", slog.String("err", err.Error()))
+			}
 		}
 
 		c.mut.Lock()

--- a/client/websocket.go
+++ b/client/websocket.go
@@ -111,14 +111,14 @@ func (c *Client) handleWSEventHello(ev *model.WebSocketEvent) (isReconnect bool,
 	}
 
 	if connID != c.currentConnID {
-		c.log.Debug("new connection id from server")
+		c.log.Debug("new connection id from server", slog.String("connID", connID))
 	}
 
 	if c.originalConnID == "" {
-		c.log.Debug("initial ws connection")
+		c.log.Debug("initial ws connection", slog.String("originalConnID", connID))
 		c.originalConnID = connID
 	} else {
-		c.log.Debug("ws reconnected successfully")
+		c.log.Debug("ws reconnected successfully", slog.String("originalConnID", c.originalConnID))
 		c.wsLastDisconnect = time.Time{}
 		c.wsReconnectInterval = 0
 		isReconnect = true

--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 
 	"github.com/pion/webrtc/v3"
+	"golang.org/x/time/rate"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
@@ -16,6 +17,7 @@ type call struct {
 	id            string
 	sessions      map[string]*session
 	screenSession *session
+	pliLimiters   map[webrtc.SSRC]*rate.Limiter
 	metrics       Metrics
 
 	mut sync.RWMutex


### PR DESCRIPTION
#### Summary

Sending keyframes can be expensive for the presenter, as it requires more bandwidth. It gets worse when N receivers concurrently ask for a keyframe. This is common when a presenter begins screen sharing in a large call.

PR introduces some rate limiting to avoid forwarding more than 1 PLI (picture loss indication) request per second.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60189