### PR TITLE
[MM-60561] RTC client metrics

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -104,6 +104,7 @@ type Client struct {
 	receivers          map[string][]*webrtc.RTPReceiver
 	voiceSender        *webrtc.RTPSender
 	screenTransceivers []*webrtc.RTPTransceiver
+	rtcMon             *rtcMonitor
 
 	state int32
 
@@ -224,6 +225,10 @@ func (c *Client) emit(eventType EventType, ctx any) {
 
 func (c *Client) close() {
 	atomic.StoreInt32(&c.state, clientStateClosed)
+
+	if c.rtcMon != nil {
+		c.rtcMon.Stop()
+	}
 
 	if c.pc != nil {
 		if err := c.pc.Close(); err != nil {

--- a/client/config.go
+++ b/client/config.go
@@ -28,6 +28,8 @@ type Config struct {
 	// EnableDCSignaling controls whether the client should use data channels
 	// for signaling of media tracks.
 	EnableDCSignaling bool
+	// EnableRTCMonitor controls whether the RTC monitor component should be enabled.
+	EnableRTCMonitor bool
 
 	wsURL string
 }

--- a/client/helper_test.go
+++ b/client/helper_test.go
@@ -357,17 +357,19 @@ func setupTestHelper(tb testing.TB, channelName string) *TestHelper {
 	}
 
 	th.adminClient, err = New(Config{
-		SiteURL:   th.apiURL,
-		AuthToken: th.adminAPIClient.AuthToken,
-		ChannelID: channelID,
+		SiteURL:          th.apiURL,
+		AuthToken:        th.adminAPIClient.AuthToken,
+		ChannelID:        channelID,
+		EnableRTCMonitor: true,
 	}, WithLogger(logger))
 	require.NoError(tb, err)
 	require.NotNil(tb, th.adminClient)
 
 	th.userClient, err = New(Config{
-		SiteURL:   th.apiURL,
-		AuthToken: th.userAPIClient.AuthToken,
-		ChannelID: channelID,
+		SiteURL:          th.apiURL,
+		AuthToken:        th.userAPIClient.AuthToken,
+		ChannelID:        channelID,
+		EnableRTCMonitor: true,
 	}, WithLogger(logger))
 	require.NoError(tb, err)
 	require.NotNil(tb, th.userClient)

--- a/client/rtc_monitor.go
+++ b/client/rtc_monitor.go
@@ -1,0 +1,195 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package client
+
+import (
+	"log/slog"
+	"time"
+
+	"github.com/pion/interceptor/pkg/stats"
+	"github.com/pion/webrtc/v3"
+)
+
+type rtcMonitor struct {
+	log         *slog.Logger
+	pc          *webrtc.PeerConnection
+	statsGetter stats.Getter
+	interval    time.Duration
+
+	lastSndStats map[webrtc.SSRC]*stats.Stats
+	lastRcvStats map[webrtc.SSRC]*stats.Stats
+
+	statsCh chan rtcStats
+	stopCh  chan struct{}
+	doneCh  chan struct{}
+}
+
+type rtcStats struct {
+	lossRate float64
+	jitter   float64
+}
+
+func newRTCMonitor(log *slog.Logger, pc *webrtc.PeerConnection, sg stats.Getter, intv time.Duration) *rtcMonitor {
+	return &rtcMonitor{
+		log:          log,
+		pc:           pc,
+		statsGetter:  sg,
+		interval:     intv,
+		statsCh:      make(chan rtcStats, 1),
+		stopCh:       make(chan struct{}),
+		doneCh:       make(chan struct{}),
+		lastSndStats: make(map[webrtc.SSRC]*stats.Stats),
+		lastRcvStats: make(map[webrtc.SSRC]*stats.Stats),
+	}
+}
+
+func (m *rtcMonitor) gatherStats() (map[webrtc.SSRC]*stats.Stats, map[webrtc.SSRC]*stats.Stats) {
+	sndStats := make(map[webrtc.SSRC]*stats.Stats)
+	for _, snd := range m.pc.GetSenders() {
+		if snd == nil {
+			continue
+		}
+		for i, enc := range snd.GetParameters().Encodings {
+			// For simplicity we only consider audio streams.
+			// This lets us more easily make assumptions on the clock rate.
+			if snd.GetParameters().Codecs[i].MimeType != webrtc.MimeTypeOpus {
+				continue
+			}
+
+			stats := m.statsGetter.Get(uint32(enc.SSRC))
+			if stats != nil {
+				sndStats[enc.SSRC] = stats
+			}
+		}
+	}
+
+	rcvStats := make(map[webrtc.SSRC]*stats.Stats)
+	for _, rcv := range m.pc.GetReceivers() {
+		if rcv == nil {
+			continue
+		}
+
+		track := rcv.Track()
+
+		if track == nil {
+			continue
+		}
+
+		// For simplicity we only consider audio streams.
+		// This lets us more easily make assumptions on the clock rate.
+		if track.Codec().MimeType != webrtc.MimeTypeOpus {
+			continue
+		}
+
+		stats := m.statsGetter.Get(uint32(track.SSRC()))
+		if stats != nil {
+			rcvStats[track.SSRC()] = stats
+		}
+	}
+
+	return sndStats, rcvStats
+}
+
+func (m *rtcMonitor) getAvgSenderStats(stats map[webrtc.SSRC]*stats.Stats) (avgLossRate, avgJitter, statsCount float64) {
+	var totalJitter, totalLossRate float64
+
+	for ssrc, s := range stats {
+		if prevStats := m.lastSndStats[ssrc]; prevStats == nil || s.OutboundRTPStreamStats.PacketsSent == prevStats.OutboundRTPStreamStats.PacketsSent {
+			continue
+		}
+
+		totalLossRate += s.RemoteInboundRTPStreamStats.FractionLost
+		totalJitter += s.RemoteInboundRTPStreamStats.Jitter
+		statsCount++
+	}
+
+	if statsCount > 0 {
+		avgJitter = (totalJitter / statsCount)
+		avgLossRate = totalLossRate / statsCount
+	}
+
+	return
+}
+
+func (m *rtcMonitor) getAvgReceiverStats(stats map[webrtc.SSRC]*stats.Stats) (avgLossRate, avgJitter, statsCount float64) {
+	var totalJitter, totalLost, totalReceived float64
+
+	for ssrc, s := range stats {
+		prevStats := m.lastRcvStats[ssrc]
+		if prevStats == nil || s.InboundRTPStreamStats.PacketsReceived == prevStats.InboundRTPStreamStats.PacketsReceived {
+			continue
+		}
+
+		receivedDiff := s.InboundRTPStreamStats.PacketsReceived - prevStats.InboundRTPStreamStats.PacketsReceived
+		potentiallyLost := int64(s.RemoteOutboundRTPStreamStats.PacketsSent) - int64(s.InboundRTPStreamStats.PacketsReceived)
+		prevPotentiallyLost := int64(prevStats.RemoteOutboundRTPStreamStats.PacketsSent) - int64(prevStats.InboundRTPStreamStats.PacketsReceived)
+		var lostDiff int64
+		if prevPotentiallyLost >= 0 && potentiallyLost > prevPotentiallyLost {
+			lostDiff = potentiallyLost - prevPotentiallyLost
+		}
+		totalLost += float64(lostDiff)
+		totalReceived += float64(receivedDiff)
+		totalJitter += s.InboundRTPStreamStats.Jitter
+
+		statsCount++
+	}
+
+	if statsCount > 0 {
+		avgJitter = (totalJitter / statsCount)
+		avgLossRate = totalLost / totalReceived
+	}
+
+	return
+}
+
+func (m *rtcMonitor) processStats(sndStats, rcvStats map[webrtc.SSRC]*stats.Stats) {
+	defer func() {
+		// cache stats for the next iteration
+		m.lastSndStats = sndStats
+		m.lastRcvStats = rcvStats
+	}()
+
+	sndLossRate, sndJitter, sndCnt := m.getAvgSenderStats(sndStats)
+	rcvLossRate, rcvJitter, rcvCnt := m.getAvgReceiverStats(rcvStats)
+
+	// nothing to do if we didn't process any stats
+	if sndCnt == 0 && rcvCnt == 0 {
+		return
+	}
+
+	select {
+	case m.statsCh <- rtcStats{lossRate: max(sndLossRate, rcvLossRate), jitter: max(sndJitter, rcvJitter)}:
+	default:
+		m.log.Error("failed to send stats: channel is full")
+	}
+}
+
+func (m *rtcMonitor) Start() {
+	m.log.Debug("starting rtc monitor")
+	go func() {
+		defer close(m.doneCh)
+		ticker := time.NewTicker(m.interval)
+
+		for {
+			select {
+			case <-ticker.C:
+				sndStats, rcvStats := m.gatherStats()
+				m.processStats(sndStats, rcvStats)
+			case <-m.stopCh:
+				return
+			}
+		}
+	}()
+}
+
+func (m *rtcMonitor) Stop() {
+	m.log.Debug("stopping rtc monitor")
+	close(m.stopCh)
+	<-m.doneCh
+	close(m.statsCh)
+}
+
+func (m *rtcMonitor) StatsCh() <-chan rtcStats {
+	return m.statsCh
+}

--- a/client/rtc_monitor.go
+++ b/client/rtc_monitor.go
@@ -105,7 +105,7 @@ func (m *rtcMonitor) getAvgSenderStats(stats map[webrtc.SSRC]*stats.Stats) (avgL
 	}
 
 	if statsCount > 0 {
-		avgJitter = (totalJitter / statsCount)
+		avgJitter = totalJitter / statsCount
 		avgLossRate = totalLossRate / statsCount
 	}
 
@@ -136,7 +136,7 @@ func (m *rtcMonitor) getAvgReceiverStats(stats map[webrtc.SSRC]*stats.Stats) (av
 	}
 
 	if statsCount > 0 {
-		avgJitter = (totalJitter / statsCount)
+		avgJitter = totalJitter / statsCount
 		avgLossRate = totalLost / totalReceived
 	}
 

--- a/client/rtc_monitor_test.go
+++ b/client/rtc_monitor_test.go
@@ -1,0 +1,121 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package client
+
+import (
+	"log/slog"
+	"os"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/pion/interceptor/pkg/stats"
+	"github.com/pion/webrtc/v3"
+
+	"github.com/stretchr/testify/require"
+)
+
+type statsGetter struct{}
+
+func (sg *statsGetter) Get(_ uint32) *stats.Stats {
+	return nil
+}
+
+func TestRTCMonitor(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+
+	pc, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	require.NoError(t, err)
+	defer pc.Close()
+
+	var sg statsGetter
+	rtcMon := newRTCMonitor(logger, pc, &sg, time.Second)
+	require.NotNil(t, rtcMon)
+
+	rtcMon.Start()
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		s := <-rtcMon.StatsCh()
+		require.Empty(t, s)
+	}()
+
+	time.Sleep(2 * time.Second)
+
+	rtcMon.Stop()
+	wg.Wait()
+}
+
+func TestRTCMonitorProcessStats(t *testing.T) {
+	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+		AddSource: true,
+		Level:     slog.LevelDebug,
+	}))
+
+	pc, err := webrtc.NewPeerConnection(webrtc.Configuration{})
+	require.NoError(t, err)
+	defer pc.Close()
+
+	var sg statsGetter
+	rtcMon := newRTCMonitor(logger, pc, &sg, time.Second)
+	require.NotNil(t, rtcMon)
+
+	rtcMon.lastSndStats = map[webrtc.SSRC]*stats.Stats{
+		45454545: {
+			RemoteInboundRTPStreamStats: stats.RemoteInboundRTPStreamStats{},
+			OutboundRTPStreamStats: stats.OutboundRTPStreamStats{
+				SentRTPStreamStats: stats.SentRTPStreamStats{
+					PacketsSent: 45,
+				},
+			},
+		},
+	}
+	rtcMon.lastRcvStats = map[webrtc.SSRC]*stats.Stats{
+		45454545: {
+			InboundRTPStreamStats: stats.InboundRTPStreamStats{
+				ReceivedRTPStreamStats: stats.ReceivedRTPStreamStats{
+					PacketsReceived: 45,
+				},
+			},
+		},
+	}
+	rtcMon.processStats(map[webrtc.SSRC]*stats.Stats{
+		45454545: {
+			RemoteInboundRTPStreamStats: stats.RemoteInboundRTPStreamStats{
+				FractionLost: 0.45,
+				ReceivedRTPStreamStats: stats.ReceivedRTPStreamStats{
+					Jitter: 0.4545,
+				},
+			},
+			OutboundRTPStreamStats: stats.OutboundRTPStreamStats{
+				SentRTPStreamStats: stats.SentRTPStreamStats{
+					PacketsSent: 4545,
+				},
+			},
+		},
+	}, map[webrtc.SSRC]*stats.Stats{
+		45454545: {
+			InboundRTPStreamStats: stats.InboundRTPStreamStats{
+				ReceivedRTPStreamStats: stats.ReceivedRTPStreamStats{
+					PacketsReceived: 4545,
+				},
+			},
+		},
+	})
+
+	select {
+	case stats := <-rtcMon.StatsCh():
+		require.Equal(t, rtcStats{
+			lossRate: 0.45,
+			jitter:   0.4545,
+		}, stats)
+	default:
+		require.Fail(t, "channel should have stats")
+	}
+}

--- a/service/rtc/dc/msg.go
+++ b/service/rtc/dc/msg.go
@@ -19,9 +19,12 @@ import (
 type MessageType uint8
 
 const (
-	MessageTypePing MessageType = iota + 1 // no payload
-	MessageTypePong                        // no payload
-	MessageTypeSDP                         // MessageSDP
+	MessageTypePing          MessageType = iota + 1 // no payload
+	MessageTypePong                                 // no payload
+	MessageTypeSDP                                  // MessageSDP
+	MessageTypeLossRate                             // float64
+	MessageTypeRoundTripTime                        // float64
+	MessageTypeJitter                               // float64
 )
 
 // Supported payloads
@@ -104,6 +107,17 @@ func DecodeMessage(msg []byte) (MessageType, any, error) {
 			return 0, nil, fmt.Errorf("failed to unpack sdp data: %w", err)
 		}
 		return MessageTypeSDP, unpacked, nil
+	case MessageTypeLossRate:
+		fallthrough
+	case MessageTypeRoundTripTime:
+		fallthrough
+	case MessageTypeJitter:
+		var payload float64
+		err := dec.Decode(&payload)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to decode message type %d: %w", t, err)
+		}
+		return MessageType(t), payload, nil
 	}
 
 	return 0, nil, fmt.Errorf("unexpected dc message type: %d", t)

--- a/service/rtc/metrics.go
+++ b/service/rtc/metrics.go
@@ -11,4 +11,9 @@ type Metrics interface {
 	IncRTPTracks(groupID string, direction, trackType string)
 	DecRTPTracks(groupID string, direction, trackType string)
 	ObserveRTPTracksWrite(groupID, trackType string, dur float64)
+
+	// Client metrics
+	ObserveRTCClientLossRate(groupID string, val float64)
+	ObserveRTCClientRTT(groupID string, val float64)
+	ObserveRTCClientJitter(groupID string, val float64)
 }

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -403,6 +403,12 @@ func (s *Server) handleDCMessage(data []byte, us *session, dataCh *webrtc.DataCh
 		if err := s.handleIncomingSDP(us, us.dcSDPCh, payload.([]byte)); err != nil {
 			return fmt.Errorf("failed to handle incoming sdp message: %w", err)
 		}
+	case dc.MessageTypeLossRate:
+		s.metrics.ObserveRTCClientLossRate(us.cfg.GroupID, payload.(float64))
+	case dc.MessageTypeRoundTripTime:
+		s.metrics.ObserveRTCClientRTT(us.cfg.GroupID, payload.(float64))
+	case dc.MessageTypeJitter:
+		s.metrics.ObserveRTCClientJitter(us.cfg.GroupID, payload.(float64))
 	}
 
 	return nil


### PR DESCRIPTION
#### Summary

PR adds support for receiving and tracking basic client metrics (round trip time, jitter and loss rate). These can then be easily surfaced through our existing Prometheus/Grafana stack (see screenshot).

I also added a basic Golang client implementation, however it's not very accurate given some limitations in the pion implementation (jitter is especially problematic). We are keeping these off by default so that we don't get wild reports from transcriber or other clients we may have in production.

#### Screenshot

![image](https://github.com/user-attachments/assets/3af9c318-0c97-4784-badd-cfaa8cc3e976)

#### Related PRs

https://github.com/mattermost/calls-common/pull/41

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60561
