### PR TITLE
Enable SCTP optimization on client side

### DIFF
--- a/client/rtc.go
+++ b/client/rtc.go
@@ -33,13 +33,11 @@ const (
 	pingInterval       = time.Second
 )
 
-var (
-	rtpVideoExtensions = []string{
-		"urn:ietf:params:rtp-hdrext:sdes:mid",
-		"urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id",
-		"urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id",
-	}
-)
+var rtpVideoExtensions = []string{
+	"urn:ietf:params:rtp-hdrext:sdes:mid",
+	"urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id",
+	"urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id",
+}
 
 func (c *Client) handleWSEventSignal(evData map[string]any) error {
 	data, ok := evData["data"].(string)
@@ -213,7 +211,10 @@ func (c *Client) initRTCSession() error {
 		}
 	}
 
-	api := webrtc.NewAPI(webrtc.WithMediaEngine(&m), webrtc.WithInterceptorRegistry(&i))
+	s := webrtc.SettingEngine{}
+	s.EnableSCTPZeroChecksum(true)
+
+	api := webrtc.NewAPI(webrtc.WithMediaEngine(&m), webrtc.WithInterceptorRegistry(&i), webrtc.WithSettingEngine(s))
 
 	pc, err := api.NewPeerConnection(cfg)
 	if err != nil {


### PR DESCRIPTION
#### Summary

> EnableSCTPZeroChecksum controls the zero checksum feature in SCTP. This removes the need to checksum every incoming/outgoing packet and will reduce latency and CPU usage. 
