### PR TITLE
Bump Postgres to v13

### DIFF
--- a/build/test/docker-compose.yaml
+++ b/build/test/docker-compose.yaml
@@ -2,7 +2,7 @@ version: '2.4'
 services:
 
   postgres:
-    image: "postgres:11"
+    image: "postgres:13"
     restart: always
     tmpfs: /var/lib/postgresql/data
     network_mode: "host"


### PR DESCRIPTION
#### Summary

Updating the testing pipelines to use the new version.

Relates to https://github.com/mattermost/mattermost/pull/30039