### PR TITLE
[MM-63296] Bump Golang version to v1.23.6

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ DOCKER_TAG              ?= ${APP_NAME}:${APP_VERSION}
 DOCKER_USER             ?= user
 DOCKER_PASSWORD         ?= password
 ## Docker Images
-DOCKER_IMAGE_GO         ?= "golang:${GO_VERSION}@sha256:027bd04b1d3b4529bf8ccebf62eb7eeeae7b7bef134a68bd419824e929ad93ad"
+DOCKER_IMAGE_GO         ?= "golang:${GO_VERSION}"
 DOCKER_IMAGE_GOLINT     += "golangci/golangci-lint:v1.64.5@sha256:9faef4dda4304c4790a14c5b8c8cd8c2715a8cb754e13f61d8ceaa358f5a454a"
 DOCKER_IMAGE_DOCKERLINT += "hadolint/hadolint:v2.12.0@sha256:9259e253a4e299b50c92006149dd3a171c7ea3c5bd36f060022b5d2c1ff0fbbe"
 DOCKER_IMAGE_COSIGN     ?= "bitnami/cosign:1.8.0@sha256:8c2c61c546258fffff18b47bb82a65af6142007306b737129a7bd5429d53629a"

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/rtcd
 
-go 1.22.7
+go 1.23.6
 
 require (
 	git.mills.io/prologic/bitcask v1.0.2


### PR DESCRIPTION
#### Summary

Bumping the Golang version used to build. 

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-63296
