### PR TITLE
[MM-62296] Implement race free signaling through DC based lock

### DIFF
--- a/service/rtc/call.go
+++ b/service/rtc/call.go
@@ -11,6 +11,7 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/rtcd/service/rtc/dc"
 )
 
 type call struct {
@@ -43,6 +44,9 @@ func (c *call) addSession(cfg SessionConfig, rtcConn *webrtc.PeerConnection, clo
 		sdpOfferInCh:       make(chan offerMessage, signalChSize),
 		sdpAnswerInCh:      make(chan webrtc.SessionDescription, signalChSize),
 		dcSDPCh:            make(chan Message, signalChSize),
+		dcOutCh:            make(chan dcMessage, signalChSize),
+		dcOpenCh:           make(chan struct{}, 1),
+		signalingLock:      dc.NewLock(),
 		closeCh:            make(chan struct{}),
 		closeCb:            closeCb,
 		doneCh:             make(chan struct{}),
@@ -76,8 +80,6 @@ func (c *call) setScreenSession(s *session) bool {
 }
 
 func (c *call) iterSessions(cb func(s *session)) {
-	c.mut.RLock()
-	defer c.mut.RUnlock()
 	for _, session := range c.sessions {
 		cb(session)
 	}

--- a/service/rtc/dc.go
+++ b/service/rtc/dc.go
@@ -1,0 +1,129 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package rtc
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/rtcd/service/rtc/dc"
+	"github.com/pion/webrtc/v4"
+)
+
+func (s *Server) handleDC(us *session, dataCh *webrtc.DataChannel) {
+	s.log.Debug("data channel open", mlog.String("sessionID", us.cfg.SessionID))
+
+	select {
+	case us.dcOpenCh <- struct{}{}:
+	default:
+		s.log.Error("failed to send open dc message", mlog.String("sessionID", us.cfg.SessionID))
+	}
+
+	go func() {
+		for {
+			select {
+			case msg := <-us.dcOutCh:
+				dcMsg, err := dc.EncodeMessage(msg.msgType, msg.payload)
+				if err != nil {
+					s.log.Error("failed to encode sdp message", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
+					continue
+				}
+
+				if err := dataCh.Send(dcMsg); err != nil {
+					s.log.Error("failed to send sdp message", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
+					continue
+				}
+			case msg := <-us.dcSDPCh:
+				dcMsg, err := dc.EncodeMessage(dc.MessageTypeSDP, msg.Data)
+				if err != nil {
+					s.log.Error("failed to encode dc message", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
+					continue
+				}
+
+				if err := dataCh.Send(dcMsg); err != nil {
+					s.log.Error("failed to send dc message", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
+					continue
+				}
+			case <-us.closeCh:
+				return
+			}
+		}
+	}()
+
+	dataCh.OnMessage(func(msg webrtc.DataChannelMessage) {
+		// DEPRECATED
+		// keeping this for compatibility with older clients (i.e. mobile)
+		if string(msg.Data) == "ping" {
+			if err := dataCh.SendText("pong"); err != nil {
+				s.log.Error("failed to send message", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
+			}
+			return
+		}
+
+		if err := s.handleDCMessage(msg.Data, us, dataCh); err != nil {
+			s.log.Error("failed to handle dc message", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
+		}
+	})
+}
+
+func (s *Server) handleDCMessage(data []byte, us *session, dataCh *webrtc.DataChannel) error {
+	mt, payload, err := dc.DecodeMessage(data)
+	if err != nil {
+		return fmt.Errorf("failed to decode DC message: %w", err)
+	}
+
+	// Identify and handle message
+	switch mt {
+	case dc.MessageTypePong:
+		// nothing to do as pong is only received by clients at this point
+	case dc.MessageTypePing:
+		data, err := dc.EncodeMessage(dc.MessageTypePong, nil)
+		if err != nil {
+			return fmt.Errorf("failed to encode pong message: %w", err)
+		}
+
+		if err := dataCh.Send(data); err != nil {
+			return fmt.Errorf("failed to send pong message: %w", err)
+		}
+	case dc.MessageTypeSDP:
+		if err := s.handleIncomingSDP(us, us.dcSDPCh, payload.([]byte)); err != nil {
+			return fmt.Errorf("failed to handle incoming sdp message: %w", err)
+		}
+	case dc.MessageTypeLossRate:
+		s.metrics.ObserveRTCClientLossRate(us.cfg.GroupID, payload.(float64))
+	case dc.MessageTypeRoundTripTime:
+		s.metrics.ObserveRTCClientRTT(us.cfg.GroupID, payload.(float64))
+	case dc.MessageTypeJitter:
+		s.metrics.ObserveRTCClientJitter(us.cfg.GroupID, payload.(float64))
+	case dc.MessageTypeLock:
+		locked := us.signalingLock.TryLock()
+		if locked {
+			us.startLockTime = time.Now()
+		}
+
+		s.log.Debug("received lock message", mlog.String("sessionID", us.cfg.SessionID), mlog.Bool("locked", locked))
+
+		select {
+		case us.dcOutCh <- dcMessage{
+			msgType: dc.MessageTypeLock,
+			payload: locked,
+		}:
+		default:
+			return fmt.Errorf("failed to send lock message: channel is full")
+		}
+	case dc.MessageTypeUnlock:
+		if !us.startLockTime.IsZero() {
+			s.metrics.ObserveRTCSignalingLockLockedTime(us.cfg.GroupID, time.Since(us.startLockTime).Seconds())
+			us.startLockTime = time.Time{}
+		}
+
+		s.log.Debug("received unlock message", mlog.String("sessionID", us.cfg.SessionID))
+		if err := us.signalingLock.Unlock(); err != nil {
+			return fmt.Errorf("failed to unlock signaling lock: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/service/rtc/dc/lock.go
+++ b/service/rtc/dc/lock.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package dc
+
+import (
+	"errors"
+	"time"
+)
+
+var (
+	ErrLockTimeout     = errors.New("lock timeout")
+	ErrAlreadyUnlocked = errors.New("already unlocked")
+)
+
+type Lock struct {
+	syncCh chan struct{}
+}
+
+func NewLock() *Lock {
+	syncCh := make(chan struct{}, 1)
+	syncCh <- struct{}{}
+	return &Lock{
+		syncCh: syncCh,
+	}
+}
+
+func (l *Lock) Lock(timeout time.Duration) error {
+	select {
+	case <-l.syncCh:
+		return nil
+	case <-time.After(timeout):
+		return ErrLockTimeout
+	}
+}
+
+func (l *Lock) TryLock() bool {
+	select {
+	case <-l.syncCh:
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *Lock) Unlock() error {
+	select {
+	case l.syncCh <- struct{}{}:
+		return nil
+	default:
+		return ErrAlreadyUnlocked
+	}
+}

--- a/service/rtc/dc/lock_test.go
+++ b/service/rtc/dc/lock_test.go
@@ -1,0 +1,211 @@
+// Copyright (c) 2022-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package dc
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewLock(t *testing.T) {
+	lock := NewLock()
+	require.NotNil(t, lock)
+	require.NotNil(t, lock.syncCh)
+}
+
+func TestLockLock(t *testing.T) {
+	t.Run("successful lock", func(t *testing.T) {
+		lock := NewLock()
+		err := lock.Lock(100 * time.Millisecond)
+		require.NoError(t, err)
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		lock := NewLock()
+		// First lock should succeed
+		err := lock.Lock(100 * time.Millisecond)
+		require.NoError(t, err)
+
+		// Second lock should timeout
+		err = lock.Lock(100 * time.Millisecond)
+		require.Error(t, err)
+		require.Equal(t, ErrLockTimeout, err)
+
+		err = lock.Unlock()
+		require.NoError(t, err)
+
+		// Third lock should succeed
+		err = lock.Lock(100 * time.Millisecond)
+		require.NoError(t, err)
+	})
+}
+
+func TestLockUnlock(t *testing.T) {
+	t.Run("successful unlock", func(t *testing.T) {
+		lock := NewLock()
+		// First acquire the lock
+		err := lock.Lock(100 * time.Millisecond)
+		require.NoError(t, err)
+
+		// Then unlock it
+		err = lock.Unlock()
+		require.NoError(t, err)
+
+		// Should be able to lock again
+		err = lock.Lock(100 * time.Millisecond)
+		require.NoError(t, err)
+	})
+
+	t.Run("already unlocked", func(t *testing.T) {
+		lock := NewLock()
+		// Lock is initially available (unlocked)
+		// Trying to unlock should return error
+		err := lock.Unlock()
+		require.Error(t, err)
+		require.Equal(t, ErrAlreadyUnlocked, err)
+	})
+}
+
+func TestLockTryLock(t *testing.T) {
+	t.Run("successful trylock", func(t *testing.T) {
+		lock := NewLock()
+		// Lock should be initially available
+		success := lock.TryLock()
+		require.True(t, success, "TryLock should succeed on a new lock")
+
+		// Trying again should fail since we already have the lock
+		success = lock.TryLock()
+		require.False(t, success, "TryLock should fail when lock is already acquired")
+
+		// After unlocking, TryLock should succeed again
+		err := lock.Unlock()
+		require.NoError(t, err)
+
+		success = lock.TryLock()
+		require.True(t, success, "TryLock should succeed after unlocking")
+	})
+
+	t.Run("trylock with concurrent access", func(t *testing.T) {
+		lock := NewLock()
+
+		// First goroutine acquires the lock
+		success := lock.TryLock()
+		require.True(t, success)
+
+		// Use a channel to coordinate between goroutines
+		done := make(chan bool)
+
+		go func() {
+			// This should fail since the lock is held by the main goroutine
+			success := lock.TryLock()
+			require.False(t, success, "TryLock should fail when lock is held by another goroutine")
+
+			// Wait for notification that lock has been released
+			<-done
+
+			// Now it should succeed
+			success = lock.TryLock()
+			require.True(t, success, "TryLock should succeed after lock is released")
+
+			// Release the lock
+			err := lock.Unlock()
+			require.NoError(t, err)
+
+			done <- true
+		}()
+
+		// Give the goroutine time to try and fail to acquire the lock
+		time.Sleep(50 * time.Millisecond)
+
+		// Release the lock
+		err := lock.Unlock()
+		require.NoError(t, err)
+
+		// Notify goroutine that lock has been released
+		done <- true
+
+		// Wait for goroutine to finish
+		<-done
+	})
+}
+
+func TestLockConcurrency(t *testing.T) {
+	t.Run("sequential acquisition", func(t *testing.T) {
+		lock := NewLock()
+
+		// Test that multiple goroutines can acquire the lock in sequence
+		done := make(chan bool)
+
+		go func() {
+			err := lock.Lock(100 * time.Millisecond)
+			require.NoError(t, err)
+
+			// Hold the lock for a short time
+			time.Sleep(50 * time.Millisecond)
+
+			err = lock.Unlock()
+			require.NoError(t, err)
+
+			done <- true
+		}()
+
+		// Wait for first goroutine to finish
+		<-done
+
+		// Second goroutine should now be able to acquire the lock
+		err := lock.Lock(100 * time.Millisecond)
+		require.NoError(t, err)
+
+		err = lock.Unlock()
+		require.NoError(t, err)
+	})
+
+	t.Run("multiple goroutines competing", func(t *testing.T) {
+		lock := NewLock()
+		numGoroutines := 5
+		acquiredCount := int32(0)
+		timeoutCount := int32(0)
+
+		// Use a WaitGroup to wait for all goroutines to complete
+		var wg sync.WaitGroup
+		wg.Add(numGoroutines)
+
+		// Start multiple goroutines that all try to acquire the lock
+		for i := 0; i < numGoroutines; i++ {
+			go func() {
+				defer wg.Done()
+
+				// Try to acquire the lock with a timeout
+				err := lock.Lock(200 * time.Millisecond)
+				if err == nil {
+					// Successfully acquired the lock
+					atomic.AddInt32(&acquiredCount, 1)
+
+					// Hold the lock briefly
+					time.Sleep(10 * time.Millisecond)
+
+					// Release the lock
+					err = lock.Unlock()
+					require.NoError(t, err)
+				} else {
+					// Timed out waiting for the lock
+					require.Equal(t, ErrLockTimeout, err)
+					atomic.AddInt32(&timeoutCount, 1)
+				}
+			}()
+		}
+
+		// Wait for all goroutines to finish
+		wg.Wait()
+
+		// Verify that at least one goroutine acquired the lock
+		// and the sum of acquired and timeout counts equals the total number of goroutines
+		require.Greater(t, acquiredCount, int32(0))
+		require.Equal(t, int32(numGoroutines), acquiredCount+timeoutCount)
+	})
+}

--- a/service/rtc/dc/msg.go
+++ b/service/rtc/dc/msg.go
@@ -25,6 +25,8 @@ const (
 	MessageTypeLossRate                             // float64
 	MessageTypeRoundTripTime                        // float64
 	MessageTypeJitter                               // float64
+	MessageTypeLock                                 // bool
+	MessageTypeUnlock                               // no payload
 )
 
 // Supported payloads
@@ -118,6 +120,18 @@ func DecodeMessage(msg []byte) (MessageType, any, error) {
 			return 0, nil, fmt.Errorf("failed to decode message type %d: %w", t, err)
 		}
 		return MessageType(t), payload, nil
+	case MessageTypeLock:
+		// MessageTypeLock can either be used as a request or as a response.
+		// A payload is expected in response only.
+		var payload bool
+		err := dec.Decode(&payload)
+		if err == nil {
+			return MessageTypeLock, payload, nil
+		}
+
+		return MessageTypeLock, nil, nil
+	case MessageTypeUnlock:
+		return MessageTypeUnlock, nil, nil
 	}
 
 	return 0, nil, fmt.Errorf("unexpected dc message type: %d", t)

--- a/service/rtc/metrics.go
+++ b/service/rtc/metrics.go
@@ -11,6 +11,10 @@ type Metrics interface {
 	IncRTPTracks(groupID string, direction, trackType string)
 	DecRTPTracks(groupID string, direction, trackType string)
 	ObserveRTPTracksWrite(groupID, trackType string, dur float64)
+	ObserveRTCConnectionTime(groupID string, dur float64)
+	ObserveRTCDataChannelOpenTime(groupID string, dur float64)
+	ObserveRTCSignalingLockGrabTime(groupID string, dur float64)
+	ObserveRTCSignalingLockLockedTime(groupID string, dur float64)
 
 	// Client metrics
 	ObserveRTCClientLossRate(groupID string, val float64)

--- a/service/rtc/sfu.go
+++ b/service/rtc/sfu.go
@@ -14,7 +14,6 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/mattermost/rtcd/service/random"
-	"github.com/mattermost/rtcd/service/rtc/dc"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 
@@ -192,6 +191,8 @@ func initInterceptors(m *webrtc.MediaEngine) (*interceptor.Registry, <-chan cc.B
 }
 
 func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
+	start := time.Now()
+
 	if err := cfg.IsValid(); err != nil {
 		return fmt.Errorf("invalid session config: %w", err)
 	}
@@ -310,6 +311,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 		if state == webrtc.PeerConnectionStateConnected {
 			s.log.Debug("rtc connected!", mlog.String("sessionID", cfg.SessionID))
 			s.metrics.IncRTCConnState("connected")
+			s.metrics.ObserveRTCConnectionTime(cfg.GroupID, time.Since(start).Seconds())
 		} else if state == webrtc.PeerConnectionStateDisconnected {
 			s.log.Debug("peer connection disconnected", mlog.String("sessionID", cfg.SessionID))
 			s.metrics.IncRTCConnState("disconnected")
@@ -339,42 +341,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 	})
 
 	peerConn.OnDataChannel(func(dataCh *webrtc.DataChannel) {
-		s.log.Debug("data channel open", mlog.String("sessionID", cfg.SessionID))
-
-		go func() {
-			for {
-				select {
-				case msg := <-us.dcSDPCh:
-					dcMsg, err := dc.EncodeMessage(dc.MessageTypeSDP, msg.Data)
-					if err != nil {
-						s.log.Error("failed to encode sdp message", mlog.Err(err), mlog.String("sessionID", cfg.SessionID))
-						continue
-					}
-
-					if err := dataCh.Send(dcMsg); err != nil {
-						s.log.Error("failed to send message", mlog.Err(err), mlog.String("sessionID", cfg.SessionID))
-						continue
-					}
-				case <-us.closeCh:
-					return
-				}
-			}
-		}()
-
-		dataCh.OnMessage(func(msg webrtc.DataChannelMessage) {
-			// DEPRECATED
-			// keeping this for compatibility with older clients (i.e. mobile)
-			if string(msg.Data) == "ping" {
-				if err := dataCh.SendText("pong"); err != nil {
-					s.log.Error("failed to send message", mlog.Err(err), mlog.String("sessionID", cfg.SessionID))
-				}
-				return
-			}
-
-			if err := s.handleDCMessage(msg.Data, us, dataCh); err != nil {
-				s.log.Error("failed to handle dc message", mlog.Err(err), mlog.String("sessionID", cfg.SessionID))
-			}
-		})
+		s.handleDC(us, dataCh)
 	})
 
 	peerConn.OnTrack(func(remoteTrack *webrtc.TrackRemote, receiver *webrtc.RTPReceiver) {
@@ -434,6 +401,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 				return
 			}
 
+			call.mut.Lock()
 			us.mut.Lock()
 			if trackType == trackTypeVoice {
 				us.outVoiceTrack = outAudioTrack
@@ -444,9 +412,14 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			us.mut.Unlock()
 
 			call.iterSessions(func(ss *session) {
-				if ss.cfg.SessionID == us.cfg.SessionID {
+				// We skip sending the track to the current session (the one sending it) and to any session
+				// that hasn't finished initializing its tracks (they are still connecting).
+				// This is to avoid queuing duplicate tracks. The call of call.mut.Lock() is needed to guarantee
+				// we won't be missing any tracks.
+				if ss.cfg.SessionID == us.cfg.SessionID || !ss.isTracksInitDone() {
 					return
 				}
+
 				select {
 				case ss.tracksCh <- trackActionContext{action: trackActionAdd, track: outAudioTrack}:
 				default:
@@ -458,6 +431,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					)
 				}
 			})
+			call.mut.Unlock()
 
 			var audioLevelExtensionID int
 			for _, ext := range receiver.GetParameters().HeaderExtensions {
@@ -571,6 +545,9 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			}
 
 			trackIdx := getTrackIndex(trackMimeType, rid)
+
+			call.mut.Lock()
+
 			us.mut.Lock()
 			us.outScreenTracks[trackIdx] = outScreenTracks
 			us.remoteScreenTracks[trackIdx] = remoteTrack
@@ -578,7 +555,11 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 			us.mut.Unlock()
 
 			call.iterSessions(func(ss *session) {
-				if ss.cfg.SessionID == us.cfg.SessionID {
+				// We skip sending the track to the current session (the one sending it) and to any session
+				// that hasn't finished initializing its tracks (they are still connecting).
+				// This is to avoid queuing duplicate tracks. The call of call.mut.Lock() is needed to guarantee
+				// we won't be missing any tracks.
+				if ss.cfg.SessionID == us.cfg.SessionID || !ss.isTracksInitDone() {
 					return
 				}
 
@@ -620,6 +601,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 					)
 				}
 			})
+			call.mut.Unlock()
 
 			writeTrack := func(writerCh <-chan *rtp.Packet, outTrack *webrtc.TrackLocalStaticRTP) {
 				for pkt := range writerCh {
@@ -693,7 +675,7 @@ func (s *Server) InitSession(cfg SessionConfig, closeCb func() error) error {
 		}
 	})
 
-	go s.handleNegotiations(us, call)
+	go s.handleDCNegotiation(us, call)
 
 	s.log.Debug("session has joined call",
 		mlog.String("userID", cfg.UserID),
@@ -770,6 +752,7 @@ func (s *Server) CloseSession(sessionID string) error {
 
 // handleTracks manages (adds and removes) a/v tracks for the peer associated with the session.
 func (s *Server) handleTracks(call *call, us *session) {
+	call.mut.Lock()
 	call.iterSessions(func(ss *session) {
 		if ss.cfg.SessionID == us.cfg.SessionID {
 			return
@@ -810,7 +793,33 @@ func (s *Server) handleTracks(call *call, us *session) {
 			}
 		}
 	})
+	us.mut.Lock()
+	us.tracksInitDone = true
+	us.mut.Unlock()
+	call.mut.Unlock()
 
+	// Incoming offers handler. This requires a dedicated goroutine since the other handler below could be blocked
+	// waiting for the signaling lock which is released by the client upon receiving an answer.
+	go func() {
+		for {
+			select {
+			case offerMsg, ok := <-us.sdpOfferInCh:
+				if !ok {
+					return
+				}
+
+				if err := us.signaling(offerMsg.sdp, offerMsg.answerCh); err != nil {
+					s.metrics.IncRTCErrors(us.cfg.GroupID, "signaling")
+					s.log.Error("failed to signal", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
+					continue
+				}
+			case <-us.closeCh:
+				return
+			}
+		}
+	}()
+
+	// Outgoing offers handler
 	for {
 		select {
 		case ctx, ok := <-us.tracksCh:
@@ -823,11 +832,22 @@ func (s *Server) handleTracks(call *call, us *session) {
 				sdpCh = us.dcSDPCh
 			}
 
+			start := time.Now()
+			err := us.signalingLock.Lock(signalingLockTimeout)
+			s.metrics.ObserveRTCSignalingLockGrabTime(us.cfg.GroupID, time.Since(start).Seconds())
+			if err != nil {
+				s.log.Error("failed to grab signaling lock", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
+				s.metrics.IncRTCErrors(us.cfg.GroupID, "signaling_lock_timeout")
+				continue
+			}
+
+			start = time.Now()
+			s.log.Debug("signaling lock acquired", mlog.String("sessionID", us.cfg.SessionID))
+
 			if ctx.action == trackActionAdd {
 				if err := us.addTrack(sdpCh, ctx.track); err != nil {
 					s.metrics.IncRTCErrors(us.cfg.GroupID, "track")
 					s.log.Error("failed to add track", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID), mlog.String("trackID", ctx.track.ID()))
-					continue
 				}
 			} else if ctx.action == trackActionRemove {
 				if err := us.removeTrack(sdpCh, ctx.track); err != nil {
@@ -837,22 +857,16 @@ func (s *Server) handleTracks(call *call, us *session) {
 						trackID = ctx.track.ID()
 					}
 					s.log.Error("failed to remove track", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID), mlog.String("trackID", trackID))
-					continue
 				}
 			} else {
 				s.log.Error("invalid track action", mlog.Int("action", int(ctx.action)), mlog.String("sessionID", us.cfg.SessionID))
-				continue
-			}
-		case offerMsg, ok := <-us.sdpOfferInCh:
-			if !ok {
-				return
 			}
 
-			if err := us.signaling(offerMsg.sdp, offerMsg.answerCh); err != nil {
-				s.metrics.IncRTCErrors(us.cfg.GroupID, "signaling")
-				s.log.Error("failed to signal", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
-				continue
+			s.log.Debug("releasing signaling lock", mlog.String("sessionID", us.cfg.SessionID))
+			if err := us.signalingLock.Unlock(); err != nil {
+				s.log.Error("failed to unlock signaling lock", mlog.Err(err), mlog.String("sessionID", us.cfg.SessionID))
 			}
+			s.metrics.ObserveRTCSignalingLockLockedTime(us.cfg.GroupID, time.Since(start).Seconds())
 		case <-us.closeCh:
 			return
 		}


### PR DESCRIPTION
#### Summary

I've finally decided to try to eliminate the various race conditions that still affect signaling because the server side does not implement the [perfect negotiation](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation) pattern.

My [previous statement](https://github.com/mattermost/mattermost-plugin-calls/pull/870#discussion_r1784648708) on this topic was not entirely accurate. Even the browser side could still get into an invalid SDP state. It was just more rare, but it was still fairly reproducible when dealing with more than a single audio track.

Anyhow, to get rid of all of this, we implement a synchronization mechanism (lock) through our data channel.

#### Related PR

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-62296
