### PR TITLE
Update getting_started.md

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -62,7 +62,7 @@ Restart=always
 RestartSec=10
 User=mattermost
 Group=mattermost
-Environment=API_SECURITY_ALLOWSELFREGISTRATION=true
+Environment=RTCD_API_SECURITY_ALLOWSELFREGISTRATION=true
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
#### Summary

It looks like this has been wrong for a long time. We must add the prefix, or it won't apply.

Overrides in https://github.com/mattermost/rtcd/blob/master/docs/env_config.md are accurate.


