### PR TITLE
[MM-64239] Extend `ICEAddressUDP` and `ICEAddressTCP` to support a specified list of addresses

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -27,6 +27,9 @@ security.session_cache.expiration_minutes = 1440
 #
 # If left empty it has the same effect as using the 0.0.0.0 catch-all address,
 # causing the server to listen on all available network interfaces.
+#
+# Since version 1.2.0 this setting supports passing multiple local addresses through
+# a comma separated list.
 ice_address_udp = ""
 # The UDP port used to route media (audio/screen/video tracks).
 ice_port_udp = 8443
@@ -35,6 +38,9 @@ ice_port_udp = 8443
 #
 # If left empty it has the same effect as using the 0.0.0.0 catch-all address,
 # causing the server to listen on all available network interfaces.
+#
+# Since version 1.2.0 this setting supports passing multiple local addresses through
+# a comma separated list.
 ice_address_tcp = ""
 # The TCP port used to route media (audio/screen/video tracks). This is used to
 # generate TCP candidates.

--- a/service/rtc/config.go
+++ b/service/rtc/config.go
@@ -13,11 +13,11 @@ import (
 
 type ServerConfig struct {
 	// ICEAddressUDP specifies the UDP address the RTC service should listen on.
-	ICEAddressUDP string `toml:"ice_address_udp"`
+	ICEAddressUDP ICEAddress `toml:"ice_address_udp"`
 	// ICEPortUDP specifies the UDP port the RTC service should listen to.
 	ICEPortUDP int `toml:"ice_port_udp"`
 	// ICEAddressTCP specifies the TCP address the RTC service should listen on.
-	ICEAddressTCP string `toml:"ice_address_tcp"`
+	ICEAddressTCP ICEAddress `toml:"ice_address_tcp"`
 	// ICEPortTCP specifies the TCP port the RTC service should listen to.
 	ICEPortTCP int `toml:"ice_port_tcp"`
 	// ICEHostOverride optionally specifies an IP address (or hostname)
@@ -41,12 +41,12 @@ type ServerConfig struct {
 }
 
 func (c ServerConfig) IsValid() error {
-	if c.ICEAddressUDP != "" && net.ParseIP(c.ICEAddressUDP) == nil {
-		return fmt.Errorf("invalid ICEAddressUDP value: not a valid address")
+	if err := c.ICEAddressUDP.IsValid(); err != nil {
+		return fmt.Errorf("invalid ICEAddressUDP value: %w", err)
 	}
 
-	if c.ICEAddressTCP != "" && net.ParseIP(c.ICEAddressTCP) == nil {
-		return fmt.Errorf("invalid ICEAddressTCP value: not a valid address")
+	if err := c.ICEAddressTCP.IsValid(); err != nil {
+		return fmt.Errorf("invalid ICEAddressTCP value: %w", err)
 	}
 
 	if c.ICEPortUDP < 80 || c.ICEPortUDP > 49151 {
@@ -339,6 +339,26 @@ func (s *ICEHostPortOverride) UnmarshalTOML(data interface{}) error {
 		*s = ICEHostPortOverride(fmt.Sprintf("%v", data))
 	default:
 		return fmt.Errorf("unknown type %T", t)
+	}
+
+	return nil
+}
+
+type ICEAddress string
+
+func (a ICEAddress) Parse() []string {
+	return strings.Split(string(a), ",")
+}
+
+func (a ICEAddress) IsValid() error {
+	if a == "" {
+		return nil
+	}
+
+	for _, addr := range a.Parse() {
+		if net.ParseIP(addr) == nil {
+			return fmt.Errorf("invalid ICEAddress value: %s is not a valid IP address", addr)
+		}
 	}
 
 	return nil

--- a/service/rtc/config_test.go
+++ b/service/rtc/config_test.go
@@ -21,12 +21,12 @@ func TestServerConfigIsValid(t *testing.T) {
 		cfg.ICEAddressUDP = "not_an_address"
 		err := cfg.IsValid()
 		require.Error(t, err)
-		require.Equal(t, "invalid ICEAddressUDP value: not a valid address", err.Error())
+		require.Equal(t, "invalid ICEAddressUDP value: invalid ICEAddress value: not_an_address is not a valid IP address", err.Error())
 
 		cfg.ICEAddressUDP = "127.0.0.0.1"
 		err = cfg.IsValid()
 		require.Error(t, err)
-		require.Equal(t, "invalid ICEAddressUDP value: not a valid address", err.Error())
+		require.Equal(t, "invalid ICEAddressUDP value: invalid ICEAddress value: 127.0.0.0.1 is not a valid IP address", err.Error())
 	})
 
 	t.Run("invalid ICEPortUDP", func(t *testing.T) {
@@ -406,5 +406,37 @@ func TestSessionProps(t *testing.T) {
 		}
 		require.Equal(t, "channelID", cfg.Props.ChannelID())
 		require.True(t, cfg.Props.AV1Support())
+	})
+}
+
+func TestICEAddressIsValid(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		var addr ICEAddress
+		err := addr.IsValid()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid single address", func(t *testing.T) {
+		addr := ICEAddress("127.0.0.1")
+		err := addr.IsValid()
+		require.NoError(t, err)
+	})
+
+	t.Run("valid multiple addresses", func(t *testing.T) {
+		addr := ICEAddress("127.0.0.1,192.168.45.45")
+		err := addr.IsValid()
+		require.NoError(t, err)
+	})
+
+	t.Run("invalid address", func(t *testing.T) {
+		addr := ICEAddress("127.0.0.256")
+		err := addr.IsValid()
+		require.EqualError(t, err, "invalid ICEAddress value: 127.0.0.256 is not a valid IP address")
+	})
+
+	t.Run("invalid address in list", func(t *testing.T) {
+		addr := ICEAddress("127.0.0.1,192.168.45.45,256.45.45.45")
+		err := addr.IsValid()
+		require.EqualError(t, err, "invalid ICEAddress value: 256.45.45.45 is not a valid IP address")
 	})
 }


### PR DESCRIPTION
#### Summary

Listening on the loopback device (i.e., `127.0.0.1`) is not always ideal and can sometimes cause issues — we've received a few reports about this. Typically, setting `ICEAddressUDP` and `ICEAddressTCP` to the IP address of the appropriate local network interface (e.g., `eth0`) is sufficient.

However, complications arise when there are multiple valid local interfaces — for example, one for the local network and another for VPN traffic. In such cases, we’re currently forced to choose between binding to all interfaces (by leaving the address value empty) or only one specific interface.

This PR introduces support for specifying a comma-separated list of local addresses for the RTC service to listen on.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64239
