### PR TITLE
Make systemd the recommended deployment option

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -17,34 +17,9 @@ docker pull mattermost/rtcd:latest
 
 ## Running
 
-### As a Docker container
-
-To start `rtcd` we can run the following command:
-
-```sh
-docker run --name rtcd -e "RTCD_LOGGER_ENABLEFILE=false" -e "RTCD_API_SECURITY_ALLOWSELFREGISTRATION=true" -p 8443:8443/udp -p 8443:8443/tcp -p 8045:8045/tcp mattermost/rtcd
-```
-
-> **_Note:_**
->
->- By default the service starts even if no configuration file is provided. In such case default values are used. In the example above we are overriding a couple of config settings:
->   - `logger.enable_file` We set this to `false` to prevent warnings since the process has no permissions to write files. If a log file is needed a volume should be mounted accordingly.
->   - `api.security.allow_self_registration` We set this to `true` so that clients (Mattermost instances) can automatically self register and authenticate to the service without manually having to create accounts. This is fine as long as the service is running in an internal/private network.
->- We are exposing to the host the two ports the service is listening on:
->   - `8443/udp` and `8443/tcp` are the ports used to route all the calls related media traffic (i.e. voice, screen share). The first one (UDP) is preferred but the latter (TCP) can be used as a fallback.
->   - `8045/tcp` Is the port used to serve the HTTP/WebSocket internal API to communicate with the Mattermost side (Calls plugin).
-
-#### Running with config file
-
-Of course it's also possible to provide the service with a complete config file by mounting a volume, e.g.:
-
-```sh
-docker run --name rtcd -v /path/to/rtcd/config:/config mattermost/rtcd -config /config/config.toml
-```
-
 ### As a systemd service
 
-Alternatively, the `rtcd` binary can be executed using a systemd service file.
+The `rtcd` binary can be executed using a systemd service file, which is the recommended way since it simplifies the configuration and management of the service.
 
 ```
 sudo touch /lib/systemd/system/rtcd.service
@@ -82,6 +57,31 @@ Enable and start the service:
 
 ```
 sudo systemctl enable --now /lib/systemd/system/rtcd.service
+```
+
+### As a Docker container
+
+Alternatively, `rtcd` can run in a Docker container using the following command:
+
+```sh
+docker run --name rtcd -e "RTCD_LOGGER_ENABLEFILE=false" -e "RTCD_API_SECURITY_ALLOWSELFREGISTRATION=true" -p 8443:8443/udp -p 8443:8443/tcp -p 8045:8045/tcp mattermost/rtcd
+```
+
+> **_Note:_**
+>
+>- By default the service starts even if no configuration file is provided. In such case default values are used. In the example above we are overriding a couple of config settings:
+>   - `logger.enable_file` We set this to `false` to prevent warnings since the process has no permissions to write files. If a log file is needed a volume should be mounted accordingly.
+>   - `api.security.allow_self_registration` We set this to `true` so that clients (Mattermost instances) can automatically self register and authenticate to the service without manually having to create accounts. This is fine as long as the service is running in an internal/private network.
+>- We are exposing to the host the two ports the service is listening on:
+>   - `8443/udp` and `8443/tcp` are the ports used to route all the calls related media traffic (i.e. voice, screen share). The first one (UDP) is preferred but the latter (TCP) can be used as a fallback.
+>   - `8045/tcp` Is the port used to serve the HTTP/WebSocket internal API to communicate with the Mattermost side (Calls plugin).
+
+#### Running with config file
+
+Of course it's also possible to provide the service with a complete config file by mounting a volume, e.g.:
+
+```sh
+docker run --name rtcd -v /path/to/rtcd/config:/config mattermost/rtcd -config /config/config.toml
 ```
 
 ### Verify service is running


### PR DESCRIPTION
#### Summary

Running `rtcd` through `systemd` is much simpler and should be the first option.
