### PR TITLE
[MM-64239] Filter out candidates for unused local addresses

### DIFF
--- a/config/config.sample.toml
+++ b/config/config.sample.toml
@@ -28,7 +28,7 @@ security.session_cache.expiration_minutes = 1440
 # If left empty it has the same effect as using the 0.0.0.0 catch-all address,
 # causing the server to listen on all available network interfaces.
 #
-# Since version 1.2.0 this setting supports passing multiple local addresses through
+# Since version 1.1.2 this setting supports passing multiple local addresses through
 # a comma separated list.
 ice_address_udp = ""
 # The UDP port used to route media (audio/screen/video tracks).
@@ -39,7 +39,7 @@ ice_port_udp = 8443
 # If left empty it has the same effect as using the 0.0.0.0 catch-all address,
 # causing the server to listen on all available network interfaces.
 #
-# Since version 1.2.0 this setting supports passing multiple local addresses through
+# Since version 1.1.2 this setting supports passing multiple local addresses through
 # a comma separated list.
 ice_address_tcp = ""
 # The TCP port used to route media (audio/screen/video tracks). This is used to

--- a/service/rtc/config.go
+++ b/service/rtc/config.go
@@ -347,6 +347,10 @@ func (s *ICEHostPortOverride) UnmarshalTOML(data interface{}) error {
 type ICEAddress string
 
 func (a ICEAddress) Parse() []string {
+	if a == "" {
+		return nil
+	}
+
 	var addrs []string
 	for _, addr := range strings.Split(string(a), ",") {
 		addrs = append(addrs, strings.TrimSpace(addr))

--- a/service/rtc/config_test.go
+++ b/service/rtc/config_test.go
@@ -409,6 +409,44 @@ func TestSessionProps(t *testing.T) {
 	})
 }
 
+func TestICEAddressParse(t *testing.T) {
+	t.Run("empty", func(t *testing.T) {
+		var addr ICEAddress
+		addrs := addr.Parse()
+		require.Nil(t, addrs)
+	})
+
+	t.Run("single address", func(t *testing.T) {
+		addr := ICEAddress("127.0.0.1")
+		addrs := addr.Parse()
+		require.Equal(t, []string{"127.0.0.1"}, addrs)
+	})
+
+	t.Run("multiple addresses", func(t *testing.T) {
+		addr := ICEAddress("127.0.0.1,192.168.1.1")
+		addrs := addr.Parse()
+		require.Equal(t, []string{"127.0.0.1", "192.168.1.1"}, addrs)
+	})
+
+	t.Run("multiple addresses with spaces", func(t *testing.T) {
+		addr := ICEAddress("127.0.0.1 , 192.168.1.1   ,  10.0.0.1")
+		addrs := addr.Parse()
+		require.Equal(t, []string{"127.0.0.1", "192.168.1.1", "10.0.0.1"}, addrs)
+	})
+
+	t.Run("single address with spaces", func(t *testing.T) {
+		addr := ICEAddress("  127.0.0.1  ")
+		addrs := addr.Parse()
+		require.Equal(t, []string{"127.0.0.1"}, addrs)
+	})
+
+	t.Run("IPv6 addresses", func(t *testing.T) {
+		addr := ICEAddress("::1,2001:db8::1")
+		addrs := addr.Parse()
+		require.Equal(t, []string{"::1", "2001:db8::1"}, addrs)
+	})
+}
+
 func TestICEAddressIsValid(t *testing.T) {
 	t.Run("empty", func(t *testing.T) {
 		var addr ICEAddress

--- a/service/rtc/server.go
+++ b/service/rtc/server.go
@@ -118,7 +118,7 @@ func (s *Server) Start() error {
 				s.localIPs = append(s.localIPs, ip)
 			}
 		}
-		s.log.Debug("rtc: ICE addresses set, overriding local IPs", mlog.Any("localIPs", s.localIPs))
+		s.log.Debug("rtc: ICE addresses set, only using filtered local IPs", mlog.Any("localIPs", s.localIPs))
 	}
 
 	if m, _ := s.cfg.ICEHostPortOverride.ParseMap(); len(m) > 0 {


### PR DESCRIPTION
#### Summary

Even when listening on specific interfaces (i.e., through the `ice_address_udp` and `ice_address_tcp` settings), the ICE layer would generate candidates for all available local addresses. This is problematic for a few reasons, but mostly because we wouldn't listen to all of those IPs. We add the necessary changes to filter out anything we are not going to listen to.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-64239
