### PR TITLE
Improve logging

### DIFF
--- a/service/auth.go
+++ b/service/auth.go
@@ -52,7 +52,7 @@ func (s *Service) basicAuthHandler(_ http.ResponseWriter, r *http.Request) (stri
 	}
 
 	if err := s.auth.Authenticate(clientID, authKey); err != nil {
-		s.log.Error("authentication failed", mlog.Err(err), mlog.String("clientID", clientID))
+		s.log.Error("service: authentication failed", mlog.Err(err), mlog.String("clientID", clientID))
 		return "", http.StatusUnauthorized, errors.New("authentication failed")
 	}
 
@@ -120,7 +120,7 @@ func (s *Service) registerClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.log.Debug("registered new client", mlog.String("clientID", clientID))
+	s.log.Info("service: registered new mattermost client", mlog.String("clientID", clientID))
 	data.code = http.StatusCreated
 	data.resData["clientID"] = clientID
 }
@@ -140,7 +140,7 @@ func (s *Service) unregisterClient(w http.ResponseWriter, r *http.Request) {
 	// If an admin client is not enabled, and self registration is not allowed,
 	// clients cannot unregister themselves.
 	if !s.cfg.API.Security.EnableAdmin && !s.cfg.API.Security.AllowSelfRegistration {
-		s.log.Warn("/unregister was called, but enable_admin and allow_self_registration are both false")
+		s.log.Warn("service: /unregister was called, but enable_admin and allow_self_registration are both false")
 		data.err = "unregister not enabled"
 		data.code = http.StatusForbidden
 		return
@@ -182,7 +182,7 @@ func (s *Service) unregisterClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.log.Debug("unregistered client", mlog.String("clientID", clientID))
+	s.log.Info("service: unregistered mattermost client", mlog.String("clientID", clientID))
 	data.code = http.StatusOK
 }
 
@@ -213,7 +213,7 @@ func (s *Service) loginClient(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	s.log.Debug("logged in client", mlog.String("clientID", clientID))
+	s.log.Info("service: logged in mattermost client", mlog.String("clientID", clientID))
 	data.code = http.StatusOK
 	data.resData["bearerToken"] = bearerToken
 }

--- a/service/ws/server_test.go
+++ b/service/ws/server_test.go
@@ -509,5 +509,5 @@ func TestRaceSendClose(t *testing.T) {
 
 	wg.Wait()
 
-	require.EqualError(t, s.Send(Message{}), "server is closed")
+	require.EqualError(t, s.Send(Message{}), "ws: server is closed")
 }


### PR DESCRIPTION
#### Summary

At `INFO` level (the default for console logging) the initial registration and connection sequence can be confusing. The first login attempt appears as an error because the Mattermost side tries to log in before attempting to register. However, the subsequent successful attempt is logged at `DEBUG` level, so it won't appear in the console by default.

#### Screenshot

*Before*

<img width="2560" height="306" alt="image" src="https://github.com/user-attachments/assets/3dad3571-78b1-481f-ba91-15f3c1a75c24" />

*After*

<img width="2560" height="388" alt="image" src="https://github.com/user-attachments/assets/7c607d84-72fe-42a0-9292-fa06f2c15594" />

