### PR TITLE
Fix simulcast screen-share layer switch dropping viewer track (MM-69486)

### DIFF
--- a/client/websocket_test.go
+++ b/client/websocket_test.go
@@ -126,11 +126,19 @@ func TestClientWSReconnectTimeout(t *testing.T) {
 	ln.Close()
 	th.userClient.cfg.wsURL = fmt.Sprintf("ws://%s", unusedAddr)
 
+	// Client.Connect auto-joins a call on the initial Hello. Because this test
+	// uses a throwaway channel the user has no access to, that join races back
+	// a spurious "forbidden" error whose timing relative to this handler's
+	// registration is nondeterministic, which previously made the test flaky.
+	// Filter it (and any other unrelated error) out and only surface the
+	// reconnection-timeout error this test actually asserts on.
 	errorCh := make(chan error, 1)
 	err = th.userClient.On(ErrorEvent, func(ctx any) error {
-		select {
-		case errorCh <- ctx.(error):
-		default:
+		if err, _ := ctx.(error); err != nil && err.Error() == "ws reconnection timeout reached" {
+			select {
+			case errorCh <- err:
+			default:
+			}
 		}
 		return nil
 	})

--- a/service/rtc/session.go
+++ b/service/rtc/session.go
@@ -248,6 +248,13 @@ func (s *session) getOutScreenTrack(mimeType, rid string) *webrtc.TrackLocalStat
 	return pickRandom(s.outScreenTracks[getTrackIndex(mimeType, rid)])
 }
 
+func (s *session) getRemoteScreenTrack(mimeType, rid string) *webrtc.TrackRemote {
+	s.mut.RLock()
+	defer s.mut.RUnlock()
+
+	return s.remoteScreenTracks[getTrackIndex(mimeType, rid)]
+}
+
 func (s *session) getExpectedSimulcastLevel() string {
 	s.mut.RLock()
 	defer s.mut.RUnlock()

--- a/service/rtc/simulcast.go
+++ b/service/rtc/simulcast.go
@@ -215,13 +215,21 @@ func (s *session) handleSenderBitrateChange(downRate int, lossRate int) (bool, i
 	// current layer rather than enqueue an add that would be rejected.
 	newRemoteTrack := screenSession.getRemoteScreenTrack(mimeType, newLevel)
 	if newRemoteTrack == nil {
-		s.log.Warn("remote screen track not available for new level")
+		s.log.Warn("remote screen track not available for new level",
+			mlog.String("mimeType", mimeType),
+			mlog.String("currLevel", currLevel),
+			mlog.String("newLevel", newLevel),
+		)
 		return false, 0, ""
 	}
 
 	sourceRate := screenSession.getSourceRate(mimeType, newLevel)
 	if sourceRate <= 0 {
-		s.log.Warn("source rate not available")
+		s.log.Warn("source rate not available",
+			mlog.String("mimeType", mimeType),
+			mlog.String("currLevel", currLevel),
+			mlog.String("newLevel", newLevel),
+		)
 		return false, 0, ""
 	}
 

--- a/service/rtc/simulcast.go
+++ b/service/rtc/simulcast.go
@@ -210,6 +210,15 @@ func (s *session) handleSenderBitrateChange(downRate int, lossRate int) (bool, i
 		return false, 0, ""
 	}
 
+	// The remote track for the new layer is required to wire up PLI forwarding
+	// in addTrack (see handleSenderRTCP). If it's not registered yet we keep the
+	// current layer rather than enqueue an add that would be rejected.
+	newRemoteTrack := screenSession.getRemoteScreenTrack(mimeType, newLevel)
+	if newRemoteTrack == nil {
+		s.log.Warn("remote screen track not available for new level")
+		return false, 0, ""
+	}
+
 	sourceRate := screenSession.getSourceRate(mimeType, newLevel)
 	if sourceRate <= 0 {
 		s.log.Warn("source rate not available")
@@ -232,7 +241,7 @@ func (s *session) handleSenderBitrateChange(downRate int, lossRate int) (bool, i
 	}
 
 	select {
-	case s.tracksCh <- trackActionContext{action: trackActionAdd, localTrack: newTrack}:
+	case s.tracksCh <- trackActionContext{action: trackActionAdd, localTrack: newTrack, remoteTrack: newRemoteTrack, senderSession: screenSession}:
 	default:
 		s.log.Error("failed to send screen track: channel is full")
 		return false, 0, ""


### PR DESCRIPTION
### Summary

Fixes [MM-69486](https://mattermost.atlassian.net/browse/MM-69486): screen-share simulcast layer switch fails with `invalid nil remoteTrack`, freezing viewers ~10–30s into a share.

When `EnableSimulcast` (experimental screen-share simulcast) is on, the rate-driven simulcast **layer switch** (low→high upgrade after `levelChangeInitialBackoff`, ~10s) removed the current screen track and then enqueued the new layer's track-add **without a `remoteTrack`**:

- `simulcast.go` → `s.tracksCh <- trackActionContext{action: trackActionAdd, localTrack: newTrack}` (no `remoteTrack`)
- dispatched in `sfu.go` → `addTrack(sdpCh, ctx.localTrack, ctx.remoteTrack=nil, ...)`
- `session.go` → `if remoteTrack == nil { return fmt.Errorf("invalid nil remoteTrack") }`

Net effect: the current layer is removed but the new layer is never added → the viewer's screen track is dropped and never restored → frozen video. Publisher is unaffected and no error surfaces to either client.

This was introduced in #185 ("Calls 1-1 video support v2"), which refactored `addTrack` to require `(localTrack, remoteTrack, senderSession)` with nil guards and renamed the `trackActionContext` field `track` → `localTrack`. The simulcast switch got only the rename, never the new `remoteTrack` field — and because the call goes through a struct literal over a channel, the omitted field defaulted to `nil` with no compile error.

### Fix

- Add `getRemoteScreenTrack(mimeType, rid)` helper (parallel to `getOutScreenTrack`).
- Thread the new layer's remote track and `senderSession` through the `trackActionAdd` enqueue in `handleSenderBitrateChange`.
- Nil-check the new layer's remote track and keep the current layer rather than enqueue a doomed add if it isn't registered yet.

Using the **new** layer's own remote track (not the old one) also keeps PLI forwarding correct, since each simulcast layer has a distinct SSRC and `handleSenderRTCP` forwards PLI by `remoteTrack.SSRC()`.

### Test

- `go build ./service/rtc/...`, `go vet ./service/rtc/...`, and the rtc package tests pass.
- Manual repro: enable screen-share simulcast, 2-participant call, share screen with ample bandwidth, confirm the viewer's screen no longer freezes ~10–30s in.

### Drive-by: fix flaky `TestClientWSReconnectTimeout`

This test (`client/websocket_test.go`) flaked in CI (~1-in-3) with `expected "ws reconnection timeout reached", actual "ws error: forbidden"`. Unrelated to the simulcast change — bundled here to unblock CI.

**Root cause:** the test uses `setupTestHelper(t, "")`, which joins a call on a random channel the user has no access to. `Client.Connect()` auto-joins on the initial `Hello`, and the calls plugin replies ~1–2ms later with a spurious `calls_error: "forbidden"`. That error races the test's own `ErrorEvent` handler registration: if the handler is registered first it captures `forbidden` and fails the assertion; otherwise the error is dropped (or never observed) and the genuine 10s reconnect-timeout fires and the test passes. The reconnection/timeout code itself was never at fault, and the dead-port reconnect target is irrelevant — the failure fires before any reconnect dial happens.

**Fix:** filter the `ErrorEvent` handler to only surface the `"ws reconnection timeout reached"` error, ignoring unrelated errors. Reproduced the flake locally (against a real MM server + Calls plugin), then verified **60/60 green** after the change.
